### PR TITLE
Add new communicate demo (cs to bg with async responses)

### DIFF
--- a/communicate/communicate-bg.js
+++ b/communicate/communicate-bg.js
@@ -6,34 +6,34 @@ function handleMessages(message, sender, sendResponse) {
 	switch (message.type) {
 		case "tabs":
 			chrome.tabs.query({currentWindow: true}, function(tabs) {
-				sendResponse ({ tabs: tabs });
+				sendResponse({ selection: message.selection, tabs: tabs });
 			});
 			break;
 		case "id":
-			sendResponse({id: chrome.runtime.id});
+			sendResponse({ selection: message.selection, id: chrome.runtime.id});
 			break;
 		case "manifest":
-			sendResponse({manifest: chrome.runtime.getManifest()});
+			sendResponse({ selection: message.selection, manifest: chrome.runtime.getManifest()});
 			break;
 		case "platform":
 			chrome.runtime.getPlatformInfo(function (info) {
-				sendResponse({platform: info});
+				sendResponse({ selection: message.selection, platform: info});
 			});
 			break;
 		case "package":
 			chrome.runtime.getPackageDirectoryEntry(function (dir) {
-				sendResponse({package: dir});
+				sendResponse({ selection: message.selection, package: dir});
 			});
 			break;
 		case "background":
 			var bg = chrome.extension.getBackgroundPage();
-			sendResponse({href: bg && bg.location && bg.location.href });
+			sendResponse({ selection: message.selection, href: bg && bg.location && bg.location.href });
 			break;
 		case "views":
-			sendResponse({viewCount: chrome.extension.getViews().length });
+			sendResponse({ selection: message.selection, viewCount: chrome.extension.getViews().length });
 			break;
 		default:
-			sendResponse({type: "default"});
+			sendResponse({ selection: message.selection, type: "default"});
 			break;
 	}
 	// return true from the event listener to indicate you wish to
@@ -50,7 +50,7 @@ chrome.tabs.query({currentWindow: true/*, active: true*/}, function(tabs) {
 	tabs.forEach(function (tab) {
 		console.log("bg sends to tab.id " + tab.id);
 		chrome.tabs.sendMessage(tab.id,
-														{"type": "ping-from-pg"}, function(response) {
+														{"type": "ping-from-bg"}, function(response) {
 			console.log("response from cs in tab " + tab.id, response);
 		});
 	});

--- a/communicate/communicate-bg.js
+++ b/communicate/communicate-bg.js
@@ -1,0 +1,57 @@
+console.log(chrome.runtime.id + " bg");
+
+function handleMessages(message, sender, sendResponse) {
+	console.log(chrome.runtime.id + " bg handleMessages");
+	console.log("bg handleMessages gets", message, sender, sendResponse);
+	switch (message.type) {
+		case "tabs":
+			chrome.tabs.query({currentWindow: true}, function(tabs) {
+				sendResponse ({ tabs: tabs });
+			});
+			break;
+		case "id":
+			sendResponse({id: chrome.runtime.id});
+			break;
+		case "manifest":
+			sendResponse({manifest: chrome.runtime.getManifest()});
+			break;
+		case "platform":
+			chrome.runtime.getPlatformInfo(function (info) {
+				sendResponse({platform: info});
+			});
+			break;
+		case "package":
+			chrome.runtime.getPackageDirectoryEntry(function (dir) {
+				sendResponse({package: dir});
+			});
+			break;
+		case "background":
+			var bg = chrome.extension.getBackgroundPage();
+			sendResponse({href: bg && bg.location && bg.location.href });
+			break;
+		case "views":
+			sendResponse({viewCount: chrome.extension.getViews().length });
+			break;
+		default:
+			sendResponse({type: "default"});
+			break;
+	}
+	// return true from the event listener to indicate you wish to
+	// send a response asynchronously (this will keep the message
+	// channel open to the other end until sendResponse is called).
+	// See https://developer.chrome.com/extensions/runtime#event-onMessage
+	return true;
+}
+
+chrome.runtime.onMessage.addListener(handleMessages);
+
+// Only for testing purposes. Disable/Enable Add-ons to initiate this
+chrome.tabs.query({currentWindow: true/*, active: true*/}, function(tabs) {
+	tabs.forEach(function (tab) {
+		console.log("bg sends to tab.id " + tab.id);
+		chrome.tabs.sendMessage(tab.id,
+														{"type": "ping-from-pg"}, function(response) {
+			console.log("response from cs in tab " + tab.id, response);
+		});
+	});
+});

--- a/communicate/communicate-cs.js
+++ b/communicate/communicate-cs.js
@@ -1,0 +1,85 @@
+console.log("communicate-cs");
+console.log(document.readyState);
+
+function handleMessages(message, sender, sendResponse) {
+	// message, sender, sendResponse are all <unavailable>|
+	console.log("cs handleMessages gets", message, sender, sendResponse);
+	sendResponse({type: "response",
+								sender: sender,
+								original: message});
+	// return true from the event listener to indicate you wish to
+	// send a response asynchronously (this will keep the message
+	// channel open to the other end until sendResponse is called).
+	// See https://developer.chrome.com/extensions/runtime#event-onMessage
+	return true;
+}
+
+chrome.runtime.onMessage.addListener(handleMessages);
+
+if (document.readyState === "complete") {
+	var div = document.createElement("div");
+	div.style.position = "fixed";
+	div.style.top = "5%";
+	div.style.left = "10%";
+	div.style.opacity = 0.85;
+	var divClose = document.createElement("div");
+	var a = document.createElement("a");
+	a.href = "CloseUI";
+	a.innerHTML = "&times;";
+	a.addEventListener("click", function (event) {
+		event.preventDefault();
+		div.parentElement.removeChild(div);
+	});
+	var h2 = document.createElement("h2");
+	var name = document.createElement("span");
+	var version = document.createElement("span");
+	name.style.margin = version.style.padding = "1em";
+	h2.appendChild(a);
+	h2.appendChild(name);
+	h2.appendChild(version);
+	var radios;
+	var sel = document.createElement("select");
+	[
+		"id",
+		"manifest",
+		// not implemented in Firefox
+		// "package",
+		// "platform",
+		"background",
+		"views",
+		"tabs"
+	].forEach(function (type) {
+		var opt = document.createElement("option");
+		opt.textContent = type;
+		opt.value = type;
+		sel.appendChild(opt);
+	});
+	var pre = document.createElement("pre");
+	sel.addEventListener('change', function (event) {
+		chrome.runtime.sendMessage({
+			"type": event.target.value}, function(response) {
+			console.log((new Error).stack.split(/\n/)[0] + " got response from bg");
+			if ("manifest" in response) {
+				name.textContent = response.manifest.name;
+				version.textContent = response.manifest.version;
+			}
+			else if (!name.textContent.length && "id" in response) {
+				// encodeURIComponent is not available in content script:
+				// div.id = window.encodeURIComponent(response.id);
+				// div.id = window.btoa(response.id);
+				name.textContent = response.id;
+			}
+			pre.textContent = JSON.stringify(response, null, 2);
+		});
+	});
+	pre.style.position = "fixed";
+	pre.style.backgroundColor = "white";
+	pre.style.maxWidth = "85%";
+	pre.style.maxHeight = "75%";
+	pre.style.overflow = "auto";
+	// pre.textContent = JSON.stringify(response, null, 2);
+	div.appendChild(h2);
+	div.appendChild(sel);
+	div.appendChild(pre);
+	document.body.appendChild(div);
+}

--- a/communicate/communicate-cs.js
+++ b/communicate/communicate-cs.js
@@ -57,7 +57,9 @@ if (document.readyState === "complete") {
 	var pre = document.createElement("pre");
 	sel.addEventListener('change', function (event) {
 		chrome.runtime.sendMessage({
-			"type": event.target.value}, function(response) {
+			"selection": window.getSelection().toString(),
+			"type": event.target.value
+		}, function(response) {
 			console.log((new Error).stack.split(/\n/)[0] + " got response from bg");
 			if ("manifest" in response) {
 				name.textContent = response.manifest.name;

--- a/communicate/manifest.json
+++ b/communicate/manifest.json
@@ -1,0 +1,27 @@
+{
+
+  "description": "Get extension info from background script via minimal overlay UI. See https://github.com/mdn/webextensions-examples/communicate",
+  "manifest_version": 2,
+  "name": "Communicate",
+  "version": "1.0",
+  "applications": {
+    "gecko": {
+      "id": "communicate@mozilla.org"
+    }
+  },
+  
+  "permissions": [
+    "tabs"
+  ],
+
+  "background": {
+    "scripts": ["communicate-bg.js"]
+  },
+  
+  "content_scripts": [
+    {
+      "matches": ["*://*.mozilla.org/*"],
+      "js": ["communicate-cs.js"]
+    }
+  ]
+}


### PR DESCRIPTION
Hi Will!

I wrote this one myself.

I'm not too fond of the `communicate` name myself, but nothing better and still short sprung to mind.

It demonstrates how the content script can obtain extension information from the background script by sending messages and receiving asynchronous responses.

I would love to find a way not having to inject the content script UI dynamically.

On the content script side there does not seem to be a way.

I'll need this for some jetpack add-ons I plan on porting once webextensions options will become available (see [1218472 – Implement options API for open extension API](https://bugzil.la/1218472)).
