### PR TITLE
Translated German strings

### DIFF
--- a/notify-link-clicks-i18n/_locales/de/messages.json
+++ b/notify-link-clicks-i18n/_locales/de/messages.json
@@ -1,17 +1,17 @@
 {
   "extensionName": {
-    "message": "My German-language example extension"
+    "message": "Meine deutschsprachige Beispielerweiterung"
   },
 
   "extensionDescription": {
-    "message": "Notifies the user of link clicks, in German",
+    "message": "Benachrichtigt den Benutzer über Linkklicks, auf deutsch",
   },
 
   "notificationTitle": {
-    "message": "Click notification, in German",
+    "message": "Klickbenachrichtigung, auf deutsch",
   },
 
   "notificationContent": {
-    "message": "You clicked $1, in German",
+    "message": "Du hast $1 angeklickt, auf deutsch",
   }
 }


### PR DESCRIPTION
In response to https://groups.google.com/d/msg/mozilla.dev.mdc/P9YgkEuVnz4/17gwVeVgAwAJ.

Note: I chose the informal 'du' instead of the formal 'Sie'.

Sebastian