### PR TITLE
improve link detection in notify-link-clicks

### DIFF
--- a/notify-link-clicks-i18n/content-script.js
+++ b/notify-link-clicks-i18n/content-script.js
@@ -1,9 +1,13 @@
 window.addEventListener("click", notifyExtension);
 
 function notifyExtension(e) {
-  console.log("content script sending message");
-  if (e.target.tagName != "A") {
-    return;
+  var target = e.target;
+  while ((target.tagName != "A" || !target.href) && target.parentNode) {
+    target = target.parentNode;
   }
-  chrome.runtime.sendMessage({"url": e.target.href});
+  if (target.tagName != "A")
+    return;
+
+  console.log("content script sending message");
+  chrome.runtime.sendMessage({"url": target.href});
 }

--- a/notify-link-clicks/content-script.js
+++ b/notify-link-clicks/content-script.js
@@ -1,9 +1,13 @@
 window.addEventListener("click", notifyExtension);
 
 function notifyExtension(e) {
-  if (e.target.tagName != "A") {
-    return;
+  var target = e.target;
+  while ((target.tagName != "A" || !target.href) && target.parentNode) {
+    target = target.parentNode;
   }
+  if (target.tagName != "A")
+    return;
+
   console.log("content script sending message");
-  chrome.runtime.sendMessage({"url": e.target.href});
+  chrome.runtime.sendMessage({"url": target.href});
 }


### PR DESCRIPTION
Original approach is a bit too naive and misses all links
that contain other elements which can grab mouse clicks.
E. g. simple target checking fails on the grid @ mozilla.org.

Traversing up the tree to look for valid links fixes this problem.