### PR TITLE
cross browser workaround for chrome.tabs.executeScripts and minor style tweaks

### DIFF
--- a/beastify/popup/choose_beast.css
+++ b/beastify/popup/choose_beast.css
@@ -1,14 +1,10 @@
 html, body {
-  height: 100px;
   width: 100px;
-  margin: 0;
 }
 
 .beast {
-  height: 30%;
-  width: 90%;
   margin: 3% auto;
-  padding-top: 6%;
+  padding: 4px;
   text-align: center;
   font-size: 1.5em;
   background-color: #E5F2F2;

--- a/beastify/popup/choose_beast.js
+++ b/beastify/popup/choose_beast.js
@@ -18,9 +18,9 @@ document.addEventListener("click", function(e) {
   }
 
   var chosenBeast = e.target.textContent;
-  
+
   chrome.tabs.executeScript(null, {
-    file: "../content_scripts/beastify.js"
+    file: "/content_scripts/beastify.js"
   });
 
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {


### PR DESCRIPTION
The current workaround applied on chrome.tabs.executeScript does not work on Chromium-based browsers.

This PR use an explicit absolute url which works on both Firefox and Chrome (and some minor tweaks on the stylesheet applied to the popup page)