### PR TITLE
handle pinned tabs correctly

### DIFF
--- a/tabs-tabs-tabs/tabs.js
+++ b/tabs-tabs-tabs/tabs.js
@@ -8,7 +8,7 @@ function firstUnpinnedTab(tabs) {
 
 document.addEventListener("click", function(e) {
   function callOnActiveTab(callback) {
-    chrome.tabs.query({}, function(tabs) {
+    chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, function(tabs) {
       for (var tab of tabs) {
         if (tab.active) {
           callback(tab, tabs);
@@ -19,21 +19,22 @@ document.addEventListener("click", function(e) {
 
   if (e.target.id === "tabs-move-beginning") {
     callOnActiveTab((tab, tabs) => {
-      var destination = 0;
+      var index = 0;
       if (!tab.pinned) {
-        destination = firstUnpinnedTab(tabs);
+        index = firstUnpinnedTab(tabs);
       }
-      chrome.tabs.move([tab.id], {index: destination});
+      chrome.tabs.move([tab.id], {index});
     });
   }
 
   if (e.target.id === "tabs-move-end") {
     callOnActiveTab((tab, tabs) => {
-      var destination = -1;
+      var index = -1;
       if (tab.pinned) {
-        destination = firstUnpinnedTab(tabs);
+        var lastPinnedTab = Math.max(0, firstUnpinnedTab(tabs) - 1);
+        index = lastPinnedTab;
       }
-      chrome.tabs.move([tab.id], {index: destination});
+      chrome.tabs.move([tab.id], {index});
     });
   }
 

--- a/tabs-tabs-tabs/tabs.js
+++ b/tabs-tabs-tabs/tabs.js
@@ -1,23 +1,39 @@
+function firstUnpinnedTab(tabs) {
+  for (var tab of tabs) {
+    if (!tab.pinned) {
+      return tab.index;
+    }
+  }
+}
+
 document.addEventListener("click", function(e) {
   function callOnActiveTab(callback) {
     chrome.tabs.query({}, function(tabs) {
       for (var tab of tabs) {
         if (tab.active) {
-          callback(tab);
+          callback(tab, tabs);
         }
       }
     });
   }
 
   if (e.target.id === "tabs-move-beginning") {
-    callOnActiveTab((tab) => {
-      chrome.tabs.move([tab.id], {index: 0});
+    callOnActiveTab((tab, tabs) => {
+      var destination = 0;
+      if (!tab.pinned) {
+        destination = firstUnpinnedTab(tabs);
+      }
+      chrome.tabs.move([tab.id], {index: destination});
     });
   }
 
   if (e.target.id === "tabs-move-end") {
-    callOnActiveTab((tab) => {
-      chrome.tabs.move([tab.id], {index: -1});
+    callOnActiveTab((tab, tabs) => {
+      var destination = -1;
+      if (tab.pinned) {
+        destination = firstUnpinnedTab(tabs);
+      }
+      chrome.tabs.move([tab.id], {index: destination});
     });
   }
 

--- a/tabs-tabs-tabs/tabs.js
+++ b/tabs-tabs-tabs/tabs.js
@@ -8,7 +8,7 @@ function firstUnpinnedTab(tabs) {
 
 document.addEventListener("click", function(e) {
   function callOnActiveTab(callback) {
-    chrome.tabs.query({windowId: chrome.windows.WINDOW_ID_CURRENT}, function(tabs) {
+    chrome.tabs.query({currentWindow: true}, function(tabs) {
       for (var tab of tabs) {
         if (tab.active) {
           callback(tab, tabs);


### PR DESCRIPTION
tabs.move() seems to treat pinned and unpinned tabs groups independently: so you can't move an unpinned tab before a pinned tab, or a pinned tab after an unpinned tab.

For example:
* if you have one pinned tab, then you can't move an unpinned tab to index 0
* if you have one unpinned tab, then you can't move a pinned tab to index -1

If you try, you get a silent failure.

This patch is intended to respect that behavior:

**Move active tab to the beginning of the window**:

* if active tab is pinned, move to index 0
* if active tab is unpinned, move to the first unpinned index

**Move active tab to the end of the window**:

* if active tab is pinned, move to the first unpinned index
* if active tab is unpinned, move to -1