### PR TITLE
remove window.parent check from contentscript

### DIFF
--- a/inpage-toolbar-ui/contentscript.js
+++ b/inpage-toolbar-ui/contentscript.js
@@ -22,15 +22,13 @@ function toggleToolbar(toolbarUI) {
   }
 }
 
-// Handle messages from the add-on background page (only in top level iframes)
-if (window.parent == window) {
-  chrome.runtime.onMessage.addListener(function(msg) {
-    if (msg == "toggle-in-page-toolbar") {
-      if (toolbarUI) {
-        toggleToolbar(toolbarUI);
-      } else {
-        toolbarUI = initToolbar();
-      }
+// Handle messages from the add-on background page
+chrome.runtime.onMessage.addListener(function(msg) {
+  if (msg == "toggle-in-page-toolbar") {
+    if (toolbarUI) {
+      toggleToolbar(toolbarUI);
+    } else {
+      toolbarUI = initToolbar();
     }
-  });
-}
+  }
+});


### PR DESCRIPTION
The manifest 'all_frames' property defaults to false, so the contentscript should not need to perform the window.parent check.

See https://github.com/mozilla/blok/pull/29#discussion_r71736456