### PR TITLE
Bug fix for history-deleter panel not expanding

### DIFF
--- a/history-deleter/history.css
+++ b/history-deleter/history.css
@@ -1,4 +1,12 @@
 html, body {
     margin: 0.2em;
     width: 350px;
+    padding: 0 0.2em;
+}
+#history {
+    width: 100%;
+}
+.link {
+    width: 100%;
+    display:block;
 }

--- a/history-deleter/history.html
+++ b/history-deleter/history.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <p>History for this domain (limited to 5 results):</p>
+    <p>History for this domain <br /> (limited to 5 results):</p>
     <p id="history"></p>
     <p><a href="#" id="clear">Clear history for this domain</a></p>
     <script src="history.js"></script>

--- a/history-deleter/history.js
+++ b/history-deleter/history.js
@@ -26,10 +26,11 @@ chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
       } else {
         for (var k in results) {
           var history = results[k];
-          var li = document.createElement('p');
-          var url = document.createTextNode(history.url);
-          li.appendChild(url);
-          list.appendChild(li);
+          var url = document.createElement('a');
+          url.innerHTML = "Link " + k;
+          url.href = history.url;
+          url.setAttribute("class", "link");
+          list.appendChild(url);
         }
       }
     }


### PR DESCRIPTION
A workaround for issue #90.

Rather than resizing the panel, store the URLs as clickable links. This way they're kept at a fixed length.

![linklist](https://cloud.githubusercontent.com/assets/9271923/19135299/7e5de56a-8b5b-11e6-837e-b9357af02e61.png)

I also made a few other (very minor) CSS changes.
