### PR TITLE
Duplicate example using the browser polyfill

### DIFF
--- a/tabs-tabs-tabs-v2/README.md
+++ b/tabs-tabs-tabs-v2/README.md
@@ -1,0 +1,11 @@
+# tabs, tabs, tabs
+
+## What it does
+
+This extension includes a browser action with a popup specified as "tabs.html".
+
+The popup lets the user perform various simple operations using the tabs API.
+
+# What it shows
+
+Demonstration of various tabs API functions.

--- a/tabs-tabs-tabs-v2/browser-polyfill.js
+++ b/tabs-tabs-tabs-v2/browser-polyfill.js
@@ -1,0 +1,338 @@
+/* @@package_name - v@@version - @@timestamp */
+/* -*- Mode: indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set sts=2 sw=2 et tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+"use strict";
+
+if (typeof browser === "undefined") {
+  // Wrapping the bulk of this polyfill in a one-time-use function is a minor
+  // optimization for Firefox. Since Spidermonkey does not fully parse the
+  // contents of a function until the first time it's called, and since it will
+  // never actually need to be called, this allows the polyfill to be included
+  // in Firefox nearly for free.
+  const wrapAPIs = () => {
+    const apiMetadata = {/* include("api-metadata.json") */};
+
+    /**
+     * A WeakMap subclass which creates and stores a value for any key which does
+     * not exist when accessed, but behaves exactly as an ordinary WeakMap
+     * otherwise.
+     *
+     * @param {function} createItem
+     *        A function which will be called in order to create the value for any
+     *        key which does not exist, the first time it is accessed. The
+     *        function receives, as its only argument, the key being created.
+     */
+    class DefaultWeakMap extends WeakMap {
+      constructor(createItem, items = undefined) {
+        super(items);
+        this.createItem = createItem;
+      }
+
+      get(key) {
+        if (!this.has(key)) {
+          this.set(key, this.createItem(key));
+        }
+
+        return super.get(key);
+      }
+    }
+
+    /**
+     * Returns true if the given object is an object with a `then` method, and can
+     * therefore be assumed to behave as a Promise.
+     *
+     * @param {*} value The value to test.
+     * @returns {boolean} True if the value is thenable.
+     */
+    const isThenable = value => {
+      return value && typeof value === "object" && typeof value.then === "function";
+    };
+
+    /**
+     * Creates and returns a function which, when called, will resolve or reject
+     * the given promise based on how it is called:
+     *
+     * - If, when called, `chrome.runtime.lastError` contains a non-null object,
+     *   the promise is rejected with that value.
+     * - If the function is called with exactly one argument, the promise is
+     *   resolved to that value.
+     * - Otherwise, the promise is resolved to an array containing all of the
+     *   function's arguments.
+     *
+     * @param {object} promise
+     *        An object containing the resolution and rejection functions of a
+     *        promise.
+     * @param {function} promise.resolve
+     *        The promise's resolution function.
+     * @param {function} promise.rejection
+     *        The promise's rejection function.
+     *
+     * @returns {function}
+     *        The generated callback function.
+     */
+    const makeCallback = promise => {
+      return (...callbackArgs) => {
+        if (chrome.runtime.lastError) {
+          promise.reject(chrome.runtime.lastError);
+        } else if (callbackArgs.length === 1) {
+          promise.resolve(callbackArgs[0]);
+        } else {
+          promise.resolve(callbackArgs);
+        }
+      };
+    };
+
+    /**
+     * Creates a wrapper function for a method with the given name and metadata.
+     *
+     * @param {string} name
+     *        The name of the method which is being wrapped.
+     * @param {object} metadata
+     *        Metadata about the method being wrapped.
+     * @param {integer} metadata.minArgs
+     *        The minimum number of arguments which must be passed to the
+     *        function. If called with fewer than this number of arguments, the
+     *        wrapper will raise an exception.
+     * @param {integer} metadata.maxArgs
+     *        The maximum number of arguments which may be passed to the
+     *        function. If called with more than this number of arguments, the
+     *        wrapper will raise an exception.
+     *
+     * @returns {function(object, ...*)}
+     *       The generated wrapper function.
+     */
+    const wrapAsyncFunction = (name, metadata) => {
+      return function asyncFunctionWrapper(target, ...args) {
+        if (args.length < metadata.minArgs) {
+          throw new Error(`Expected at least ${metadata.minArgs} arguments for ${name}(), got ${args.length}`);
+        }
+
+        if (args.length > metadata.maxArgs) {
+          throw new Error(`Expected at most ${metadata.maxArgs} arguments for ${name}(), got ${args.length}`);
+        }
+
+        return new Promise((resolve, reject) => {
+          target[name](...args, makeCallback({resolve, reject}));
+        });
+      };
+    };
+
+    /**
+     * Wraps an existing method of the target object, so that calls to it are
+     * intercepted by the given wrapper function. The wrapper function receives,
+     * as its first argument, the original `target` object, followed by each of
+     * the arguments passed to the orginal method.
+     *
+     * @param {object} target
+     *        The original target object that the wrapped method belongs to.
+     * @param {function} method
+     *        The method being wrapped. This is used as the target of the Proxy
+     *        object which is created to wrap the method.
+     * @param {function} wrapper
+     *        The wrapper function which is called in place of a direct invocation
+     *        of the wrapped method.
+     *
+     * @returns {Proxy<function>}
+     *        A Proxy object for the given method, which invokes the given wrapper
+     *        method in its place.
+     */
+    const wrapMethod = (target, method, wrapper) => {
+      return new Proxy(method, {
+        apply(targetMethod, thisObj, args) {
+          return wrapper.call(thisObj, target, ...args);
+        },
+      });
+    };
+
+    let hasOwnProperty = Function.call.bind(Object.prototype.hasOwnProperty);
+
+    /**
+     * Wraps an object in a Proxy which intercepts and wraps certain methods
+     * based on the given `wrappers` and `metadata` objects.
+     *
+     * @param {object} target
+     *        The target object to wrap.
+     *
+     * @param {object} [wrappers = {}]
+     *        An object tree containing wrapper functions for special cases. Any
+     *        function present in this object tree is called in place of the
+     *        method in the same location in the `target` object tree. These
+     *        wrapper methods are invoked as described in {@see wrapMethod}.
+     *
+     * @param {object} [metadata = {}]
+     *        An object tree containing metadata used to automatically generate
+     *        Promise-based wrapper functions for asynchronous. Any function in
+     *        the `target` object tree which has a corresponding metadata object
+     *        in the same location in the `metadata` tree is replaced with an
+     *        automatically-generated wrapper function, as described in
+     *        {@see wrapAsyncFunction}
+     *
+     * @returns {Proxy<object>}
+     */
+    const wrapObject = (target, wrappers = {}, metadata = {}) => {
+      let cache = Object.create(null);
+
+      let handlers = {
+        has(target, prop) {
+          return prop in target || prop in cache;
+        },
+
+        get(target, prop, receiver) {
+          if (prop in cache) {
+            return cache[prop];
+          }
+
+          if (!(prop in target)) {
+            return undefined;
+          }
+
+          let value = target[prop];
+
+          if (typeof value === "function") {
+            // This is a method on the underlying object. Check if we need to do
+            // any wrapping.
+
+            if (typeof wrappers[prop] === "function") {
+              // We have a special-case wrapper for this method.
+              value = wrapMethod(target, target[prop], wrappers[prop]);
+            } else if (hasOwnProperty(metadata, prop)) {
+              // This is an async method that we have metadata for. Create a
+              // Promise wrapper for it.
+              let wrapper = wrapAsyncFunction(prop, metadata[prop]);
+              value = wrapMethod(target, target[prop], wrapper);
+            } else {
+              // This is a method that we don't know or care about. Return the
+              // original method, bound to the underlying object.
+              value = value.bind(target);
+            }
+          } else if (typeof value === "object" && value !== null &&
+                     (hasOwnProperty(wrappers, prop) ||
+                      hasOwnProperty(metadata, prop))) {
+            // This is an object that we need to do some wrapping for the children
+            // of. Create a sub-object wrapper for it with the appropriate child
+            // metadata.
+            value = wrapObject(value, wrappers[prop], metadata[prop]);
+          } else {
+            // We don't need to do any wrapping for this property,
+            // so just forward all access to the underlying object.
+            Object.defineProperty(cache, prop, {
+              configurable: true,
+              enumerable: true,
+              get() {
+                return target[prop];
+              },
+              set(value) {
+                target[prop] = value;
+              },
+            });
+
+            return value;
+          }
+
+          cache[prop] = value;
+          return value;
+        },
+
+        set(target, prop, value, receiver) {
+          if (prop in cache) {
+            cache[prop] = value;
+          } else {
+            target[prop] = value;
+          }
+          return true;
+        },
+
+        defineProperty(target, prop, desc) {
+          return Reflect.defineProperty(cache, prop, desc);
+        },
+
+        deleteProperty(target, prop) {
+          return Reflect.deleteProperty(cache, prop);
+        },
+      };
+
+      return new Proxy(target, handlers);
+    };
+
+    /**
+     * Creates a set of wrapper functions for an event object, which handles
+     * wrapping of listener functions that those messages are passed.
+     *
+     * A single wrapper is created for each listener function, and stored in a
+     * map. Subsequent calls to `addListener`, `hasListener`, or `removeListener`
+     * retrieve the original wrapper, so that  attempts to remove a
+     * previously-added listener work as expected.
+     *
+     * @param {DefaultWeakMap<function, function>} wrapperMap
+     *        A DefaultWeakMap object which will create the appropriate wrapper
+     *        for a given listener function when one does not exist, and retrieve
+     *        an existing one when it does.
+     *
+     * @returns {object}
+     */
+    const wrapEvent = wrapperMap => ({
+      addListener(target, listener, ...args) {
+        target.addListener(wrapperMap.get(listener), ...args);
+      },
+
+      hasListener(target, listener) {
+        return target.hasListener(wrapperMap.get(listener));
+      },
+
+      removeListener(target, listener) {
+        target.removeListener(wrapperMap.get(listener));
+      },
+    });
+
+    const onMessageWrappers = new DefaultWeakMap(listener => {
+      if (typeof listener !== "function") {
+        return listener;
+      }
+
+      /**
+       * Wraps a message listener function so that it may send responses based on
+       * its return value, rather than by returning a sentinel value and calling a
+       * callback. If the listener function returns a Promise, the response is
+       * sent when the promise either resolves or rejects.
+       *
+       * @param {*} message
+       *        The message sent by the other end of the channel.
+       * @param {object} sender
+       *        Details about the sender of the message.
+       * @param {function(*)} sendResponse
+       *        A callback which, when called with an arbitrary argument, sends
+       *        that value as a response.
+       * @returns {boolean}
+       *        True if the wrapped listener returned a Promise, which will later
+       *        yield a response. False otherwise.
+       */
+      return function onMessage(message, sender, sendResponse) {
+        let result = listener(message, sender);
+
+        if (isThenable(result)) {
+          result.then(sendResponse, error => {
+            console.error(error);
+            sendResponse(error);
+          });
+
+          return true;
+        } else if (result !== undefined) {
+          sendResponse(result);
+        }
+      };
+    });
+
+    const staticWrappers = {
+      runtime: {
+        onMessage: wrapEvent(onMessageWrappers),
+      },
+    };
+
+    return wrapObject(chrome, staticWrappers, apiMetadata);
+  };
+
+  this.browser = wrapAPIs();
+}

--- a/tabs-tabs-tabs-v2/manifest.json
+++ b/tabs-tabs-tabs-v2/manifest.json
@@ -1,0 +1,12 @@
+{
+  "browser_action": {
+      "browser_style": true,
+      "default_title": "Tabs, tabs, tabs",
+      "default_popup": "tabs.html"
+  },
+  "description": "A list of methods you can perform on a tab.",
+  "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs-v2",
+  "manifest_version": 2,
+  "name": "Tabs, tabs, tabs",
+  "version": "2.0"
+}

--- a/tabs-tabs-tabs-v2/tabs.css
+++ b/tabs-tabs-tabs-v2/tabs.css
@@ -1,0 +1,12 @@
+html, body {
+  width: 350px;
+}
+
+a {
+  margin: 10px;
+  display: inline-block;
+}
+
+.panel {
+  margin: 5px;
+}

--- a/tabs-tabs-tabs-v2/tabs.html
+++ b/tabs-tabs-tabs-v2/tabs.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="tabs.css"/>
+  </head>
+
+<body>
+  <div class="panel">
+    <div class="panel-section panel-section-header">
+      <div class="text-section-header">Tabs-tabs-tabs</div>
+    </div>
+
+    <a href="#" id="tabs-move-beginning">Move active tab to the beginning of the window</a><br>
+    <a href="#" id="tabs-move-end">Move active tab to the end of the window</a><br>
+
+    <div class="panel-section-separator"></div>
+
+    <a href="#" id="tabs-duplicate">Duplicate active tab</a><br>
+    <a href="#" id="tabs-reload">Reload active tab</a><br>
+    <a href="#" id="tabs-alertinfo">Alert active tab info</a><br>
+
+    <div class="panel-section-separator"></div>
+
+    <a href="#" id="tabs-create">Create a tab</a><br>
+    <a href="#" id="tabs-remove">Remove active tab</a><br>
+
+    <div class="panel-section-separator"></div>
+
+    <a href="#" id="tabs-add-zoom">Zoom in</a><br>
+    <a href="#" id="tabs-default-zoom">Reset zoom</a><br>
+    <a href="#" id="tabs-decrease-zoom">Zoom out</a>
+
+  </div>
+
+  <script type="application/javascript" src="browser-polyfill.js"></script>
+  <script type="application/javascript" src="tabs.js"></script>
+</body>
+
+</html>

--- a/tabs-tabs-tabs-v2/tabs.js
+++ b/tabs-tabs-tabs-v2/tabs.js
@@ -1,0 +1,144 @@
+// Zoom constants. Define Max, Min, increment and default values
+const ZOOM_INCREMENT = 0.2;
+const MAX_ZOOM = 3;
+const MIN_ZOOM = 0.3;
+const DEFAULT_ZOOM = 1;
+
+function firstUnpinnedTab(tabs) {
+  for (var tab of tabs) {
+    if (!tab.pinned) {
+      return tab.index;
+    }
+  }
+}
+
+document.addEventListener("click", function(e) {
+  function callOnActiveTab(callback) {
+    browser.tabs.query({currentWindow: true}, function(tabs) {
+      for (var tab of tabs) {
+        if (tab.active) {
+          callback(tab, tabs);
+        }
+      }
+    });
+  }
+
+  if (e.target.id === "tabs-move-beginning") {
+    callOnActiveTab((tab, tabs) => {
+      var index = 0;
+      if (!tab.pinned) {
+        index = firstUnpinnedTab(tabs);
+      }
+      browser.tabs.move([tab.id], {index});
+    });
+  }
+
+  if (e.target.id === "tabs-move-end") {
+    callOnActiveTab((tab, tabs) => {
+      var index = -1;
+      if (tab.pinned) {
+        var lastPinnedTab = Math.max(0, firstUnpinnedTab(tabs) - 1);
+        index = lastPinnedTab;
+      }
+      browser.tabs.move([tab.id], {index});
+    });
+  }
+
+  else if (e.target.id === "tabs-duplicate") {
+    callOnActiveTab((tab) => {
+      browser.tabs.duplicate(tab.id);
+    });
+  }
+
+  else if (e.target.id === "tabs-reload") {
+    callOnActiveTab((tab) => {
+      browser.tabs.reload(tab.id);
+    });
+  }
+
+  else if (e.target.id === "tabs-remove") {
+    callOnActiveTab((tab) => {
+      browser.tabs.remove(tab.id);
+    });
+  }
+
+  else if (e.target.id === "tabs-create") {
+    browser.tabs.create({url: "https://developer.mozilla.org/en-US/Add-ons/WebExtensions"});
+  }
+
+  else if (e.target.id === "tabs-alertinfo") {
+    callOnActiveTab((tab) => {
+      let props = "";
+      for (let item in tab) {
+        props += `${ item } = ${ tab[item] } \n`;
+      }
+      alert(props);
+    });
+  }
+
+  else if (e.target.id === "tabs-add-zoom") {
+    callOnActiveTab((tab) => {
+      browser.tabs.getZoom(tab.id, function(zoomFactor){
+        //the maximum zoomFactor is 3, it can't go higher
+        if (zoomFactor >= MAX_ZOOM) {
+          alert("Tab zoom factor is already at max!");
+        } else {
+          var newZoomFactor = zoomFactor + ZOOM_INCREMENT;
+          //if the newZoomFactor is set to higher than the max accepted
+          //it won't change, and will never alert that it's at maximum
+          newZoomFactor = newZoomFactor > MAX_ZOOM ? MAX_ZOOM : newZoomFactor;
+          browser.tabs.setZoom(tab.id, newZoomFactor);
+        }
+      });
+    });
+  }
+
+  else if (e.target.id === "tabs-decrease-zoom") {
+    callOnActiveTab((tab) => {
+      browser.tabs.getZoom(tab.id, function(zoomFactor){
+        //the minimum zoomFactor is 0.3, it can't go lower
+        if (zoomFactor <= MIN_ZOOM) {
+          alert("Tab zoom factor is already at minimum!");
+        } else {
+          var newZoomFactor = zoomFactor - ZOOM_INCREMENT;
+          //if the newZoomFactor is set to lower than the min accepted
+          //it won't change, and will never alert that it's at minimum
+          newZoomFactor = newZoomFactor < MIN_ZOOM ? MIN_ZOOM : newZoomFactor;
+          browser.tabs.setZoom(tab.id, newZoomFactor);
+        }
+      });
+    });
+  }
+
+  else if (e.target.id === "tabs-default-zoom") {
+    callOnActiveTab((tab) => {
+      browser.tabs.getZoom(tab.id, function(zoomFactor){
+        if (zoomFactor == DEFAULT_ZOOM) {
+          alert("Tab zoom is already at the default zoom factor");
+        } else {
+          browser.tabs.setZoom(tab.id, DEFAULT_ZOOM);
+        }
+      });
+    });
+  }
+
+  e.preventDefault();
+});
+
+//onRemoved listener. fired when tab is removed
+browser.tabs.onRemoved.addListener(function(tabId, removeInfo){
+  console.log(`The tab with id: ${tabId}, is closing`);
+
+  if(removeInfo.isWindowClosing) {
+    console.log(`Its window is also closing.`);
+  } else {
+    console.log(`Its window is not closing`);
+  }
+});
+
+//onMoved listener. fired when tab is moved into the same window
+browser.tabs.onMoved.addListener(function(tabId, moveInfo){
+  var startIndex = moveInfo.fromIndex;
+  var endIndex = moveInfo.toIndex;
+  console.log(`Tab with id: ${tabId} moved from index: ${startIndex} to index: ${endIndex}`);
+});


### PR DESCRIPTION
This commit creates a second version of the tabs, tabs, tabs example but
using the WebExtension browser API polyfill to demonstrate the possibility
to use the same extension on Firefox and Google Chrome without any
modifications to the source code.