### PR TITLE
add in tabs permission to access the title

### DIFF
--- a/tabs-tabs-tabs/manifest.json
+++ b/tabs-tabs-tabs/manifest.json
@@ -6,13 +6,16 @@
     }
   },
   "browser_action": {
-      "browser_style": true,
-      "default_title": "Tabs, tabs, tabs",
-      "default_popup": "tabs.html"
+    "browser_style": true,
+    "default_title": "Tabs, tabs, tabs",
+    "default_popup": "tabs.html"
   },
   "description": "A list of methods you can perform on a tab.",
   "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/tabs-tabs-tabs",
   "manifest_version": 2,
   "name": "Tabs, tabs, tabs",
+  "permissions": [
+    "tabs"
+  ],
   "version": "1.0"
 }


### PR DESCRIPTION
cc @iampeterbanjo, this adds in the tabs permission so you can get the title for the switcher, which I think you mentioned in a previous pull request.