### PR TITLE
Remove applications key wherever possible

### DIFF
--- a/apply-css/manifest.json
+++ b/apply-css/manifest.json
@@ -6,13 +6,6 @@
   "version": "1.0",
   "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/apply-css",
 
-  "applications": {
-    "gecko": {
-      "id": "apply-css@mozilla.org",
-      "strict_min_version": "49.0"
-    }
-  },
-
   "background": {
     "scripts": ["background.js"]
   },

--- a/beastify/manifest.json
+++ b/beastify/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/beasts-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "beastify@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  },
-
   "permissions": [
     "activeTab"
   ],  

--- a/bookmark-it/manifest.json
+++ b/bookmark-it/manifest.json
@@ -9,13 +9,6 @@
     "96": "icons/bookmark-it@2x.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "bookmark-it-extension@mozilla.org",
-      "strict_min_version": "47.0a1"
-    }
-  },
-
   "permissions": [
     "bookmarks",
     "tabs"

--- a/borderify/manifest.json
+++ b/borderify/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/border-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "borderify@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  },
-
   "content_scripts": [
     {
       "matches": ["*://*.mozilla.org/*"],

--- a/chill-out/manifest.json
+++ b/chill-out/manifest.json
@@ -8,12 +8,6 @@
     "48": "icons/chillout-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "chillout-page-action@mozilla.org"
-    }
-  },
-
   "permissions": [
     "alarms",
     "tabs"

--- a/commands/manifest.json
+++ b/commands/manifest.json
@@ -7,12 +7,7 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "applications": {
-    "gecko": {
-      "id": "commands@mozilla.org",
-      "strict_min_version": "48.0a1"
-    }
-  },
+
   "commands": {
     "toggle-feature": {
       "suggested_key": { "default": "Ctrl+Shift+U" },

--- a/context-menu-demo/manifest.json
+++ b/context-menu-demo/manifest.json
@@ -5,13 +5,6 @@
   "version": "1.0",
   "default_locale": "en",
 
-  "applications": {
-    "gecko": {
-      "id": "context-menu-demo@mozilla.org",
-      "strict_min_version": "48.0"
-    }
-  },
-
   "background": {
     "scripts": ["background.js"]
   },

--- a/cookie-bg-picker/manifest.json
+++ b/cookie-bg-picker/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/bgpicker-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "quicknote@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  }, 
-
   "permissions": [
       "tabs",
       "cookies",

--- a/emoji-substitution/manifest.json
+++ b/emoji-substitution/manifest.json
@@ -1,11 +1,5 @@
 {
   "manifest_version": 2,
-  "applications": {
-    "gecko": {
-      "strict_min_version": "49.0.1"
-    }
-  },
-
   "name": "Emoji Substitution",
   "description": "Replaces words with emojis.",
   "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/emoji-substitution",

--- a/favourite-colour/manifest.json
+++ b/favourite-colour/manifest.json
@@ -1,10 +1,4 @@
 {
-  "applications": {
-    "gecko": {
-      "id": "some-options@mozilla.org",
-      "strict_min_version": "48.0a1"
-    }
-  },
   "background": {
       "scripts": ["background.js"]
   },

--- a/history-deleter/manifest.json
+++ b/history-deleter/manifest.json
@@ -1,10 +1,4 @@
 {
-  "applications": {
-    "gecko": {
-      "id": "history-deleter@mozilla.com",
-      "strict_min_version": "49.0a2"
-    }
-  },
   "background": {
     "scripts": ["background.js"]
   },

--- a/latest-download/manifest.json
+++ b/latest-download/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/page-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "latest-download@mozilla.org",
-      "strict_min_version": "48.0a1"
-    }
-  },
-
   "permissions": [
     "downloads",
     "downloads.open"

--- a/list-cookies/manifest.json
+++ b/list-cookies/manifest.json
@@ -1,10 +1,4 @@
 {
-  "applications": {
-    "gecko": {
-      "id": "list-cookies@mozilla.org",
-      "strict_min_version": "47.0a1"
-    }
-  },
   "browser_action": {
     "browser_style": true,
     "default_title": "List cookies in the active tab",

--- a/notify-link-clicks-i18n/manifest.json
+++ b/notify-link-clicks-i18n/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/link-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "notify-link-clicks-i18n@mozilla.org",
-      "strict_min_version": "46.0a1"
-    }
-  },
-
   "permissions": ["notifications"],
 
   "background": {

--- a/open-my-page-button/manifest.json
+++ b/open-my-page-button/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/page-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "open-my-page-button@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  },
-
   "background": {
     "scripts": ["background.js"]
   },

--- a/page-to-extension-messaging/manifest.json
+++ b/page-to-extension-messaging/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/message-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "page-to-extension-messaging@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  },
-
   "content_scripts": [
     {
       "matches": ["https://mdn.github.io/webextensions-examples/content-script-page-script-messaging.html"],

--- a/quicknote/manifest.json
+++ b/quicknote/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/quicknote-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "quicknote@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  }, 
-
   "permissions": [
     "storage"
   ], 

--- a/selection-to-clipboard/manifest.json
+++ b/selection-to-clipboard/manifest.json
@@ -9,12 +9,6 @@
         "48": "icons/clipboard-48.png"
     },
 
-    "applications": {
-        "gecko": {
-            "strict_min_version": "51.0a1"
-        }
-    },
-
     "content_scripts": [{
         "matches": ["<all_urls>"],
         "js": ["content-script.js"]

--- a/tabs-tabs-tabs/manifest.json
+++ b/tabs-tabs-tabs/manifest.json
@@ -1,10 +1,4 @@
 {
-  "applications": {
-    "gecko": {
-      "id": "tabs-tabs-tabs@mozilla.org",
-      "strict_min_version": "47.0a1"
-    }
-  },
   "browser_action": {
     "browser_style": true,
     "default_title": "Tabs, tabs, tabs",

--- a/user-agent-rewriter/manifest.json
+++ b/user-agent-rewriter/manifest.json
@@ -9,13 +9,6 @@
     "48": "icons/person-48.png"
   },
 
-  "applications": {
-    "gecko": {
-      "id": "user-agent-rewriter@mozilla.org",
-      "strict_min_version": "45.0"
-    }
-  },
-
   "permissions": [
     "webRequest", "webRequestBlocking", "http://useragentstring.com/*" 
   ],


### PR DESCRIPTION
Fix for https://github.com/mdn/webextensions-examples/issues/71, following the plan from https://github.com/mdn/webextensions-examples/issues/71#issuecomment-253642541, but also taking into account @andymckay 's https://github.com/mdn/webextensions-examples/issues/71#issuecomment-253645244.

I've removed the applications key in all cases except:
* the embedded-* examples, since they need and explicit ID and a newer-than-released Firefox
* native-messaging, for the same reasons (actually this requires Firefox 50, which is the release, but only just...)
* navigation-stats, since it needs Firefox 50, which is only just the release
