### PR TITLE
make user-agent check case insenstive

### DIFF
--- a/user-agent-rewriter/README.md
+++ b/user-agent-rewriter/README.md
@@ -2,9 +2,9 @@
 
 ## What it does
 
-This extension uses the webRequest API to rewrite the browser's User Agent header, but only when visiting pages under "http://useragentstring.com/".
+This extension uses the webRequest API to rewrite the browser's User Agent header, but only when visiting pages under "https://httpbin.org", for example: https://httpbin.org/user-agent
 
-It adds a browser action. The browser action has a popup that lets the user choose one of three browsers: Firefox 41, Chrome 41, and IE 11. When the user chooses a browser, the extension then rewrites the User Agent header so the real browser identifies itself as the chosen browser on the site http://useragentstring.com/.
+It adds a browser action. The browser action has a popup that lets the user choose one of three browsers: Firefox 41, Chrome 41, and IE 11. When the user chooses a browser, the extension then rewrites the User Agent header so the real browser identifies itself as the chosen browser on the site https://httpbin.org/.
 
 ## What it shows
 

--- a/user-agent-rewriter/background.js
+++ b/user-agent-rewriter/background.js
@@ -3,7 +3,7 @@
 /*
 This is the page for which we want to rewrite the User-Agent header.
 */
-var targetPage = "http://useragentstring.com/*";
+var targetPage = "https://httpbin.org/*";
 
 /*
 Map browser names to UA strings.
@@ -24,7 +24,7 @@ Rewrite the User-Agent header to "ua".
 */
 function rewriteUserAgentHeader(e) {
   for (var header of e.requestHeaders) {
-    if (header.name == "User-Agent") {
+    if (header.name.toLowerCase() === "user-agent") {
       header.value = ua;
     }
   }


### PR DESCRIPTION
* fixes #158 

It looks like http://useragentstring.com/* checks for a capitalized user-agent http header, where as httpbin does not, so let's move over to using that.