### PR TITLE
Changed URL to httpbin.org in the permissions

### DIFF
--- a/user-agent-rewriter/manifest.json
+++ b/user-agent-rewriter/manifest.json
@@ -10,7 +10,7 @@
   },
 
   "permissions": [
-    "webRequest", "webRequestBlocking", "http://useragentstring.com/*" 
+    "webRequest", "webRequestBlocking", "https://httpbin.org/*" 
   ],
   
   "background": {


### PR DESCRIPTION
It looks like in a previous change the website used to demonstrate the
useragent rewriting was changed but the addon permission wasn't updated
so the demonstration didn't work.