### PR TITLE
Use manifest key instead of executeScript to load content script

### DIFF
--- a/cookie-bg-picker/background_scripts/background.js
+++ b/cookie-bg-picker/background_scripts/background.js
@@ -1,12 +1,10 @@
 /* Retrieve any previously set cookie and send to content script */
 
-browser.tabs.onUpdated.addListener(cookieUpdate);
-
 function getActiveTab() {
   return browser.tabs.query({active: true, currentWindow: true});
 }
 
-function cookieUpdate(tabId, changeInfo, tab) {
+function cookieUpdate() {
   getActiveTab().then((tabs) => {
     // get any previously set cookie for the current tab 
     var gettingCookies = browser.cookies.get({
@@ -22,3 +20,8 @@ function cookieUpdate(tabId, changeInfo, tab) {
     });
   }); 
 }
+
+// update when the tab is updated
+browser.tabs.onUpdated.addListener(cookieUpdate);
+// update when the tab is activated
+browser.tabs.onActivated.addListener(cookieUpdate);

--- a/cookie-bg-picker/background_scripts/background.js
+++ b/cookie-bg-picker/background_scripts/background.js
@@ -8,19 +8,13 @@ function getActiveTab() {
 
 function cookieUpdate(tabId, changeInfo, tab) {
   getActiveTab().then((tabs) => {
-    /* inject content script into current tab */
-
-    browser.tabs.executeScript(null, {
-      file: "/content_scripts/updatebg.js"
-    });
-
     // get any previously set cookie for the current tab 
     var gettingCookies = browser.cookies.get({
       url: tabs[0].url,
       name: "bgpicker"
     });
     gettingCookies.then((cookie) => {
-      if(cookie) {
+      if (cookie) {
         var cookieVal = JSON.parse(cookie.value);
         browser.tabs.sendMessage(tabs[0].id, {image: cookieVal.image});
         browser.tabs.sendMessage(tabs[0].id, {color: cookieVal.color});

--- a/cookie-bg-picker/content_scripts/updatebg.js
+++ b/cookie-bg-picker/content_scripts/updatebg.js
@@ -1,13 +1,12 @@
-var html = document.querySelector('html');
-var body = document.querySelector('body');
-
 browser.runtime.onMessage.addListener(updateBg);
 
 function updateBg(request, sender, sendResponse) {
-  if(request.image) {
+  var html = document.querySelector('html');
+  var body = document.querySelector('body');
+  if (request.image) {
     html.style.backgroundImage = 'url(' + request.image + ')';
     body.style.backgroundImage = 'url(' + request.image + ')';
-  } else if(request.color) {
+  } else if (request.color) {
     html.style.backgroundColor = request.color;
     body.style.backgroundColor = request.color;
   } else if (request.reset) {

--- a/cookie-bg-picker/manifest.json
+++ b/cookie-bg-picker/manifest.json
@@ -36,5 +36,12 @@
 
   "background": {
     "scripts": ["background_scripts/background.js"]
-  }
+  },
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_scripts/updatebg.js"]
+    }
+  ]
 }


### PR DESCRIPTION
This is a fix for https://github.com/mdn/webextensions-examples/issues/197.

I think the problem there is that the background script loads the content script using tabs.executeScript, but only does so on tabs.onUpdated. So if you install the add-on, then try to set a background for a page that was already open, the content script isn't yet loaded into that page. The popup then tries to send a message to the nonexistent script and you get an error.

The fix here is to load the content script using the content_scripts manifest key, so it's always there.

I've also changed the code that checks for cookies so it checks on activate as well as update.
