### PR TITLE
Add examples of different window types

### DIFF
--- a/window-manipulator/window.html
+++ b/window-manipulator/window.html
@@ -13,16 +13,21 @@
       </div>
 
       <a href="#" id="window-update-size_768">Resize window to 768x1024</a><br>
+      <a href="#" id="window-resize-all">Resize all windows to 1024x768</a><br>
       <a href="#" id="window-update-minimize">Minimize</a><br>
 
       <div class="panel-section-separator"></div>
 
       <a href="#" id="window-create-incognito">Create new incognito window</a><br>
-      <a href="#" id="window-remove">Remove active window</a><br>
+      <a href="#" id="window-create-normal">Create normal window</a><br>
+      <a href="#" id="window-create-panel">Create panel</a><br>
+      <a href="#" id="window-create-detached-panel">Create detached panel</a><br>
+      <a href="#" id="window-create-popup">Create popup</a><br>
 
       <div class="panel-section-separator"></div>
 
-      <a href="#" id="window-resize-all">Resize all windows to 1024x768</a><br>
+      <a href="#" id="window-remove">Remove active window</a><br>
+
     </div>
 
   <script src="window.js"></script>

--- a/window-manipulator/window.js
+++ b/window-manipulator/window.js
@@ -25,6 +25,14 @@ document.addEventListener("click", (e) => {
     });
   }
 
+  else if (e.target.id === "window-create-normal") {
+    var createData = {};
+    var creating = browser.windows.create(createData);
+    creating.then(() => {
+      console.log("The normal window has been created");
+    });
+  }
+
   else if (e.target.id === "window-create-incognito") {
     var createData = {
       incognito: true,
@@ -32,6 +40,36 @@ document.addEventListener("click", (e) => {
     var creating = browser.windows.create(createData);
     creating.then(() => {
       console.log("The incognito window has been created");
+    });
+  }
+
+  else if (e.target.id === "window-create-panel") {
+    var createData = {
+      type: "panel",
+    };
+    var creating = browser.windows.create(createData);
+    creating.then(() => {
+      console.log("The panel has been created");
+    });
+  }
+
+  else if (e.target.id === "window-create-detached-panel") {
+    var createData = {
+      type: "detached_panel",
+    };
+    var creating = browser.windows.create(createData);
+    creating.then(() => {
+      console.log("The detached panel has been created");
+    });
+  }
+
+  else if (e.target.id === "window-create-popup") {
+    var createData = {
+      type: "popup",
+    };
+    var creating = browser.windows.create(createData);
+    creating.then(() => {
+      console.log("The popup has been created");
     });
   }
 


### PR DESCRIPTION
Here's a PR for this issue: https://github.com/mdn/webextensions-examples/issues/189. It seems that all types except "normal" are treated the same (http://searchfox.org/mozilla-central/source/browser/components/extensions/ext-windows.js#142) which makes it not terribly exciting. I should document this.

If we wanted to add more things to this add-on we should change the UI (for example, giving it a drop-down for type, and a checkbox for incognito, plus a "create" button). But for now I have done the simple thing.
