### PR TITLE
Use webextensions env from eslint

### DIFF
--- a/eslint-example/.eslintrc.json
+++ b/eslint-example/.eslintrc.json
@@ -1,14 +1,8 @@
 {
-    "globals": {
-        "browser": true,
-        "chrome": true
-    },
-    "rules": {
-        "no-set-state": "off"
-    },
     "env": {
         "browser": true,
-        "es6": true
+        "es6": true,
+        "webextensions": true
     },
     "extends": [
       "eslint:recommended"

--- a/eslint-example/package.json
+++ b/eslint-example/package.json
@@ -1,16 +1,15 @@
 {
-    "name": "eslint-example",
-    "version": "1.0.0",
-    "description": "",
-    "main": "index.js",
-    "dependencies": {},
-    "devDependencies": {
-        "eslint": "^3.9.0"
-    },
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "lint": "eslint ."
-    },
-    "author": "",
-    "license": "ISC"
+  "name": "eslint-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "devDependencies": {
+    "eslint": "^3.19.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint ."
+  },
+  "author": "",
+  "license": "ISC"
 }


### PR DESCRIPTION
eslint provides an env option for webextensions. Use that instead. It also seems the single rule left in the config is from react or similar - for sure not vanilla eslint.