### PR TITLE
Simplify options styles

### DIFF
--- a/proxy-blocker/manifest.json
+++ b/proxy-blocker/manifest.json
@@ -23,7 +23,8 @@
   },
 
   "options_ui": {
-    "page": "options/options.html"
+    "page": "options/options.html",
+    "browser_style": true
   },
 
   "permissions": ["proxy", "storage"]

--- a/proxy-blocker/options/options.css
+++ b/proxy-blocker/options/options.css
@@ -1,14 +1,4 @@
-body {
-  width: 25em;
-  font-family: "Open Sans Light", sans-serif;
-  font-size: 0.9em;
-  font-weight: 300;
-}
-
-.title, #blocked-hosts {
-  margin: 1em;
-}
-
-.title {
-  font-size: 1.2em;
+#blocked-hosts {
+  display: block;
+  margin-top: 1em;
 }


### PR DESCRIPTION
Since `browser_style` is true by default for options pages from Firefox 55, we don't actually need most of the CSS in this example.
