### PR TITLE
Fix value check in page-to-extension-messaging example

### DIFF
--- a/page-to-extension-messaging/content-script.js
+++ b/page-to-extension-messaging/content-script.js
@@ -4,7 +4,7 @@ If the message was from the page script, show an alert.
 */
 window.addEventListener("message", function(event) {
   if (event.source == window &&
-      event.data.direction &&
+      event.data &&
       event.data.direction == "from-page-script") {
     alert("Content script received message: \"" + event.data.message + "\"");
   }


### PR DESCRIPTION
Check the value of "event.data" before dereferencing it, to avoid errors when void messages are sent using postMessage.

And remove the "event.data.direction" truthness check, because the actual value is already tested at the next line.