### PR TITLE
Reflect bookmark state in icon title for accessibility to screen readers

### DIFF
--- a/bookmark-it/background.js
+++ b/bookmark-it/background.js
@@ -16,6 +16,11 @@ function updateIcon() {
     },
     tabId: currentTab.id
   });
+  browser.browserAction.setTitle({
+    // Screen readers can see the title
+    title: currentBookmark ? 'Unbookmark it!' : 'Bookmark it!',
+    tabId: currentTab.id
+  }); 
 }
 
 /*


### PR DESCRIPTION
I'm not sure if this is truly the right way to handle accessibility - seems like there should be something like the `alt` attribute on `<img>`, but if there is, I can't find it. I've confirmed at least that Windows Narrator reads the icon title, but I haven't tested with other screen readers.