### PR TITLE
Update `proxy-blocker` extension to be compatible with firefox 56+

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -315,7 +315,7 @@
         "javascript_apis": [
             "extension.getURL",
             "proxy.onProxyError",
-            "proxy.registerProxyScript",
+            "proxy.register",
             "runtime.onMessage",
             "runtime.sendMessage",
             "storage.local",

--- a/proxy-blocker/background/proxy-handler.js
+++ b/proxy-blocker/background/proxy-handler.js
@@ -7,7 +7,7 @@ const defaultSettings = {
  }
 
 // Register the proxy script
-browser.proxy.registerProxyScript(proxyScriptURL);
+browser.proxy.register(proxyScriptURL);
 
 // Log any errors from the proxy script
 browser.proxy.onProxyError.addListener(error => {

--- a/proxy-blocker/manifest.json
+++ b/proxy-blocker/manifest.json
@@ -12,7 +12,7 @@
 
   "applications": {
     "gecko": {
-      "strict_min_version": "55.0a1"
+      "strict_min_version": "56.0a1"
     }
   },
 

--- a/proxy-blocker/proxy/proxy-script.js
+++ b/proxy-blocker/proxy/proxy-script.js
@@ -1,7 +1,7 @@
 /* exported FindProxyForURL */
 
 var blockedHosts = [];
-const allow = "DIRECT 1234";
+const allow = "DIRECT";
 const deny = "PROXY 127.0.0.1:65535";
 
 // tell the background script that we are ready


### PR DESCRIPTION
According to [this note](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/proxy/register#compatNote_1) `browser.proxy.registerProxyScript` was changed to `browser.proxy.register`.

I've tested and in firefox 56 `browser.proxy.registerProxyScript` doesn't work anymore