### PR TITLE
change shortcut to Ctrl+Shift+U for commands example

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -82,7 +82,7 @@
             "commands.onCommand"
         ],
         "name": "commands",
-        "description": "Demonstrates using the commands API to set up a keyboard shortcut. The shortcut created is accessed using Ctrl+Shift+Y (Command+Shift+Y on a Mac)."
+        "description": "Demonstrates using the commands API to set up a keyboard shortcut. The shortcut created is accessed using Ctrl+Shift+U (Command+Shift+U on a Mac)."
     },
     {
         "javascript_apis": [


### PR DESCRIPTION
Fix for keybord shortcut description to Ctrl+Shift+U on [MDN Example extensions page](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples).