### PR TITLE
Use for...in instead of for...of

### DIFF
--- a/history-deleter/history.js
+++ b/history-deleter/history.js
@@ -65,7 +65,7 @@ function clearAll(e) {
     // Loop through them and delete them one by one.
     var searchingHistory = browser.history.search({text: hostname})
     searchingHistory.then((results) => {
-        for (let k of results) {
+        for (let k in results) {
           browser.history.deleteUrl({url: results[k].url});
         }
         // Clear out the UI.


### PR DESCRIPTION
This example doesn't work as expected - it does not clear the history.
`for...of` on `Array` returns its elements but array indexes are required, which could be done by `for...in` statement.