### PR TITLE
Update onCommand action for the commands example

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -1,13 +1,6 @@
 # commands
 
-This extension includes:
+This extension shows how to use the `commands` manifest key to register keyboard shortcuts for your extension.
 
-* a background script, "background.js"
-
-All it does is:
-
-* register a shortcut (Ctrl+Shift+U) to send a command to the extension (Command+Shift+U on a Mac).",
-
-It shows:
-
-* how to use browser.commands to register keyboard shortcuts for your extension.
+It registers a shortcut (Ctrl+Shift+U) to send a command to the extension (Command+Shift+U on a Mac).
+When the user enters the shortcut, the extension opens a new browser tab and loads https://developer.mozilla.org into it.

--- a/commands/background.js
+++ b/commands/background.js
@@ -13,6 +13,8 @@
 var gettingAllCommands = browser.commands.getAll();
 gettingAllCommands.then((commands) => {
   for (let command of commands) {
+    // Note that this logs to the Add-on Debugger's console: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Debugging
+    // not the regular Web console.
     console.log(command);
   }
 });
@@ -24,5 +26,5 @@ gettingAllCommands.then((commands) => {
  * On Mac, this command will automatically be converted to "Command+Shift+U".
  */
 browser.commands.onCommand.addListener((command) => {
-  console.log("onCommand event received for message: ", command);
+  browser.tabs.create({url: "https://developer.mozilla.org"});
 });


### PR DESCRIPTION
Change the `onCommand` handler to open a new tab instead of logging. See https://github.com/mdn/webextensions-examples/issues/331 for the rationale.

I also added a comment to the place we are still logging, and updated the README.
