### PR TITLE
fix: Update devtools.panels.create icon and panel urls to work correctly on Firefox >= 58

### DIFF
--- a/devtools-panels/devtools/devtools.js
+++ b/devtools-panels/devtools/devtools.js
@@ -16,8 +16,8 @@ Create a panel, and add listeners for panel show/hide events.
 */
 browser.devtools.panels.create(
   "My Panel",
-  "icons/star.png",
-  "devtools/panel/panel.html"
+  "/icons/star.png",
+  "/devtools/panel/panel.html"
 ).then((newPanel) => {
   newPanel.onShown.addListener(handleShown);
   newPanel.onHidden.addListener(handleHidden);


### PR DESCRIPTION
This PR applies a small change to the devtools-panel example so that it works correctly on Firefox >= 58 (and also be still compatible with the behavior on Firefox < 58).

See [Bugzilla 1433055 comment 1](https://bugzilla.mozilla.org/show_bug.cgi?id=1433055#c1) for a more detailed rationale.