### PR TITLE
Use a valid version number for private-browsing-theme

### DIFF
--- a/private-browsing-theme/manifest.json
+++ b/private-browsing-theme/manifest.json
@@ -10,7 +10,7 @@
   "applications": {
     "gecko": {
       "id": "private-window-theme@mozilla.org",
-      "strict_min_version": "57.0b14"
+      "strict_min_version": "58.0"
     }
   }
 }


### PR DESCRIPTION
Fix for https://github.com/mdn/webextensions-examples/issues/341. Let's just use 58 at this point.