### PR TITLE
Make menus calls synch

### DIFF
--- a/menu-labelled-open/background.js
+++ b/menu-labelled-open/background.js
@@ -16,11 +16,11 @@ browser.menus.onClicked.addListener((info, tab) => {
   }
 });
 
-async function updateMenuItem(linkHostname) {
-  await browser.menus.update(openLabelledId, {
+function updateMenuItem(linkHostname) {
+  browser.menus.update(openLabelledId, {
     title: `Open (${linkHostname})`
   });
-  await browser.menus.refresh();
+  browser.menus.refresh();
 }
 
 browser.menus.onShown.addListener(info => {


### PR DESCRIPTION
This makes the calls to menus.update and menus.refresh synchronous, so we don't need to check that the original menu is still open, as per https://bugzilla.mozilla.org/show_bug.cgi?id=1215376#c182.