### PR TITLE
Removed newline in URL causing match error

### DIFF
--- a/google-userinfo/background/authorize.js
+++ b/google-userinfo/background/authorize.js
@@ -4,10 +4,10 @@ const REDIRECT_URL = browser.identity.getRedirectURL();
 const CLIENT_ID = "YOUR-CLIENT-ID";
 const SCOPES = ["openid", "email", "profile"];
 const AUTH_URL =
-`https://accounts.google.com/o/oauth2/auth
-?client_id=${CLIENT_ID}
-&response_type=token
-&redirect_uri=${encodeURIComponent(REDIRECT_URL)}
+`https://accounts.google.com/o/oauth2/auth\
+?client_id=${CLIENT_ID}\
+&response_type=token\
+&redirect_uri=${encodeURIComponent(REDIRECT_URL)}\
 &scope=${encodeURIComponent(SCOPES.join(' '))}`;
 const VALIDATION_BASE_URL="https://www.googleapis.com/oauth2/v3/tokeninfo";
 


### PR DESCRIPTION
The backticks in multiline strings cause the newline characters to be present in the final URL. This causes a TypeError (tested in Firefox 60) because it must match /^https?:\/\/.*$/) for identity.launchWebAuthFlow.
Fixed and tested by adding backslashes to the end of the line to prevent the newline characters from appearing in the URL.
Before: https://accounts.google.com/o/oauth2/auth\n?client_id=[...]
After: https://accounts.google.com/o/oauth2/auth?client_id=[...]