### PR TITLE
Add access keys to the menu-demo example

### DIFF
--- a/menu-demo/_locales/en/messages.json
+++ b/menu-demo/_locales/en/messages.json
@@ -10,42 +10,42 @@
   },
 
   "menuItemSelectionLogger": {
-    "message": "Log '%s' to the browser console",
+    "message": "&Log '%s' to the browser console",
     "description": "Title of context menu item that logs the selected text when clicked."
   },
 
   "menuItemRemoveMe": {
-    "message": "Remove me!",
+    "message": "&Remove me!",
     "description": "Title of context menu item that removes itself when clicked."
   },
 
   "menuItemGreenify": {
-    "message": "Greenify",
+    "message": "&Greenify",
     "description": "Title of context menu item that adds a green border when clicked."
   },
 
   "menuItemBluify": {
-    "message": "Bluify",
+    "message": "&Bluify",
     "description": "Title of context menu item that adds a green border when clicked."
   },
 
   "menuItemCheckMe": {
-    "message": "Check me",
+    "message": "&Check me",
     "description": "Title of context menu item when the item is checked."
   },
 
   "menuItemUncheckMe": {
-    "message": "Uncheck me",
+    "message": "&Uncheck me",
     "description": "Title of context menu item when the item is unchecked."
   },
 
   "menuItemOpenSidebar": {
-    "message": "Open sidebar",
+    "message": "&Open sidebar",
     "description": "Title of context menu item that opens a sidebar."
   },
 
   "menuItemToolsMenu": {
-    "message": "Click me!",
+    "message": "&Click me!",
     "description": "Title of tools menu item."
   }
 

--- a/menu-demo/manifest.json
+++ b/menu-demo/manifest.json
@@ -7,7 +7,7 @@
   "default_locale": "en",
   "applications": {
     "gecko": {
-      "strict_min_version": "56.0a1"
+      "strict_min_version": "63.0a1"
     }
   },
 


### PR DESCRIPTION
This PR adds access keys to the menu-demo example. Access key support was added in Firefox 63 (https://bugzilla.mozilla.org/show_bug.cgi?id=1320462), so it also bumps the strict_min_version.

With this updated example you should be able to select the items in the extension's menu using Command+<key> (on macOS). For example:

* load the extension
* visit example.com
* activate the "Menu demo" submenu in the context menu
* press Command + B (on macOS)
* you should see the blue border being added


