### PR TITLE
Make cookie-bg-picker example work in private browser

### DIFF
--- a/cookie-bg-picker/background_scripts/background.js
+++ b/cookie-bg-picker/background_scripts/background.js
@@ -1,24 +1,25 @@
 /* Retrieve any previously set cookie and send to content script */
 
 function getActiveTab() {
-  return browser.tabs.query({active: true, currentWindow: true});
+  return browser.tabs.query({ active: true, currentWindow: true });
 }
 
 function cookieUpdate() {
-  getActiveTab().then((tabs) => {
-    // get any previously set cookie for the current tab 
+  getActiveTab().then(tabs => {
+    // get any previously set cookie for the current tab
     var gettingCookies = browser.cookies.get({
       url: tabs[0].url,
-      name: "bgpicker"
+      name: "bgpicker",
+      storeId: tabs[0].cookieStoreId // needed for the extension to properly work in private mode
     });
-    gettingCookies.then((cookie) => {
+    gettingCookies.then(cookie => {
       if (cookie) {
         var cookieVal = JSON.parse(cookie.value);
-        browser.tabs.sendMessage(tabs[0].id, {image: cookieVal.image});
-        browser.tabs.sendMessage(tabs[0].id, {color: cookieVal.color});
+        browser.tabs.sendMessage(tabs[0].id, { image: cookieVal.image });
+        browser.tabs.sendMessage(tabs[0].id, { color: cookieVal.color });
       }
     });
-  }); 
+  });
 }
 
 // update when the tab is updated

--- a/cookie-bg-picker/popup/bgpicker.js
+++ b/cookie-bg-picker/popup/bgpicker.js
@@ -1,73 +1,76 @@
 /* initialise variables */
 
-var bgBtns = document.querySelectorAll('.bg-container button');
-var colorPick = document.querySelector('input');
-var reset = document.querySelector('.color-reset button');
-var cookieVal = { image : '',
-                  color : '' };
+var bgBtns = document.querySelectorAll(".bg-container button");
+var colorPick = document.querySelector("input");
+var reset = document.querySelector(".color-reset button");
+var cookieVal = { image: "", color: "" };
 
 function getActiveTab() {
-  return browser.tabs.query({active: true, currentWindow: true});
+  return browser.tabs.query({ active: true, currentWindow: true });
 }
 
 /* apply backgrounds to buttons */
 /* add listener so that when clicked, button applies background to page HTML */
 
-for(var i = 0; i < bgBtns.length; i++) {
-  var imgName = bgBtns[i].getAttribute('class');
-  var bgImg = 'url(\'images/' + imgName + '.png\')';
+for (var i = 0; i < bgBtns.length; i++) {
+  var imgName = bgBtns[i].getAttribute("class");
+  var bgImg = "url('images/" + imgName + ".png')";
   bgBtns[i].style.backgroundImage = bgImg;
 
   bgBtns[i].onclick = function(e) {
-    getActiveTab().then((tabs) => {
-      var imgName = e.target.getAttribute('class');
-      var fullURL = browser.extension.getURL('popup/images/'+ imgName + '.png');
-      browser.tabs.sendMessage(tabs[0].id, {image: fullURL});
+    getActiveTab().then(tabs => {
+      var imgName = e.target.getAttribute("class");
+      var fullURL = browser.extension.getURL(
+        "popup/images/" + imgName + ".png"
+      );
+      browser.tabs.sendMessage(tabs[0].id, { image: fullURL });
 
       cookieVal.image = fullURL;
       browser.cookies.set({
         url: tabs[0].url,
-        name: "bgpicker", 
+        name: "bgpicker",
+        storeId: tabs[0].cookieStoreId, // needed for the extension to properly work in private mode
         value: JSON.stringify(cookieVal)
-      })
+      });
     });
-  }
+  };
 }
 
 /* apply chosen color to HTML background */
 
 colorPick.onchange = function(e) {
-  getActiveTab().then((tabs) => {
+  getActiveTab().then(tabs => {
     var currColor = e.target.value;
-    browser.tabs.sendMessage(tabs[0].id, {color: currColor});
+    browser.tabs.sendMessage(tabs[0].id, { color: currColor });
 
     cookieVal.color = currColor;
     browser.cookies.set({
       url: tabs[0].url,
-      name: "bgpicker", 
+      name: "bgpicker",
+      storeId: tabs[0].cookieStoreId, // needed for the extension to properly work in private mode
       value: JSON.stringify(cookieVal)
-    })
+    });
   });
-}
+};
 
 /* reset background */
 
 reset.onclick = function() {
-  getActiveTab().then((tabs) => {
-    browser.tabs.sendMessage(tabs[0].id, {reset: true});
+  getActiveTab().then(tabs => {
+    browser.tabs.sendMessage(tabs[0].id, { reset: true });
 
-    cookieVal = { image : '',
-                  color : '' };
+    cookieVal = { image: "", color: "" };
     browser.cookies.remove({
       url: tabs[0].url,
-      name: "bgpicker" 
-    })
+      storeId: tabs[0].cookieStoreId, // needed for the extension to properly work in private mode
+      name: "bgpicker"
+    });
   });
-}
+};
 
 /* Report cookie changes to the console */
 
-browser.cookies.onChanged.addListener((changeInfo) => {
+browser.cookies.onChanged.addListener(changeInfo => {
   console.log(`Cookie changed:\n
               * Cookie: ${JSON.stringify(changeInfo.cookie)}\n
               * Cause: ${changeInfo.cause}\n


### PR DESCRIPTION
I updated the cookie-bg-picker example in order for it to work in private browser.

This update can be useful to beginners since using  the _cookies API_ methods won't provide any useful information about why their program isn't doing what they expect it to do (e.g. remove a cookie in private browser).