### PR TITLE
Replace cat GIF source

### DIFF
--- a/chill-out/README.md
+++ b/chill-out/README.md
@@ -2,17 +2,16 @@
 
 ## What it does
 
-After N seconds of inactivity (defined as the user not having navigated
+After 6 seconds of inactivity (defined as the user not having navigated
 or switched away from the active tab) display a
 [page action](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/pageAction)
 for that tab.
 
-When the user clicks the page action,
-navigate to http://chilloutandwatchsomecatgifs.com/.
+When the user clicks the page action, navigate to https://giphy.com/explore/cat.
 
-"N" is set to 6 seconds in this example. Such a short period is chosen to make
-the extension's behavior more obvious, but this is not recommended in real life.
-Note that in Chrome, alarms cannot be set for less than a minute. In Chrome:
+The delay of 6 seconds is to make the extension's behavior obvious, but such a short
+period is not recommended in practical applications. Note that in Chrome, alarms do not 
+fire in under a minute. In Chrome:
 
 * if you install this extension "unpacked", you'll see a warning
 in the console, but the alarm will still go off after 6 seconds
@@ -21,6 +20,8 @@ a minute.
 
 ## What it shows
 
-* how to use various `tabs` functions
-* how to show/hide a page action
-* how to set alarms and handle alarms going off
+How to:
+
+* use various `tabs` functions.
+* show and hide a page action.
+* set alarms and handle alarms going off.

--- a/chill-out/background.js
+++ b/chill-out/background.js
@@ -9,7 +9,7 @@ in the console, but the alarm will still go off after 6 seconds
 a minute.
 */
 var DELAY = 0.1;
-var CATGIFS = "http://chilloutandwatchsomecatgifs.com/";
+var CATGIFS = "https://giphy.com/explore/cat";
 
 /*
 Restart alarm for the currently active tab, whenever background.js is run.


### PR DESCRIPTION
chilloutandwatchsomecatgifs.com now appears to serve ads. Replaced the link opened on activating the page action with https://giphy.com/explore/cat. Also made some minor improvements to the readme file.