### PR TITLE
quicknote chrome compatibility

### DIFF
--- a/proxy-blocker/options/options.js
+++ b/proxy-blocker/options/options.js
@@ -14,12 +14,10 @@ function updateUI(restoredSettings) {
   blockedHostsTextArea.value = restoredSettings.blockedHosts.join("\n");
 }
 
-function onError(e) {
-  console.error(e);
-}
-
 // On opening the options page, fetch stored settings and update the UI with them.
-browser.storage.local.get().then(updateUI, onError);
+browser.storage.local.get(['blockedHosts'], function(result) {
+  updateUI(result);
+});
 
 // Whenever the contents of the textarea changes, save the new values
 blockedHostsTextArea.addEventListener("change", storeSettings);


### PR DESCRIPTION
I want to make addons for every browser, not just chrome.
`var browser = browser || chrome;` helped me out, but there was something what did not worked in Chrome. After some research, I found [this page](https://developer.chrome.com/apps/storage).

```
chrome.storage.local.get(['key'], function(result) {
  console.log('Value currently is ' + result.key);
});
```
It's compatible with Firefox and Chrome also, but I lost the `onerror` callback. How can I get back it without breaking the compatibility?