### PR TITLE
Bump eslint from 3.19.0 to 7.6.0 in /eslint-example

### DIFF
--- a/eslint-example/package.json
+++ b/eslint-example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "devDependencies": {
-    "eslint": "^3.19.0"
+    "eslint": "^7.6.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This pull request fixes a security vulnerability and bumps eslint from 3.19.0 to 7.6.0.