### PR TITLE
Use URL interface in apply-css example

### DIFF
--- a/apply-css/background.js
+++ b/apply-css/background.js
@@ -29,9 +29,8 @@ function toggleCSS(tab) {
 Returns true only if the URL's protocol is in APPLICABLE_PROTOCOLS.
 */
 function protocolIsApplicable(url) {
-  var anchor =  document.createElement('a');
-  anchor.href = url;
-  return APPLICABLE_PROTOCOLS.includes(anchor.protocol);
+  const protocol = (new URL(url)).protocol;
+  return APPLICABLE_PROTOCOLS.includes(protocol);
 }
 
 /*

--- a/apply-css/background.js
+++ b/apply-css/background.js
@@ -27,6 +27,7 @@ function toggleCSS(tab) {
 
 /*
 Returns true only if the URL's protocol is in APPLICABLE_PROTOCOLS.
+Argument url must be a valid URL string.
 */
 function protocolIsApplicable(url) {
   const protocol = (new URL(url)).protocol;


### PR DESCRIPTION
By using the URL interface, the user is ascertained that the piece of code does not manipulate the DOM.  Keeping them in the right mental context for the example.

The apply-css example uses the protocol of the URL of the tab to determine if a [pageAction](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction) should be shown.  Any page that is hosted over http or https will receive the pageAction.

The former implementation creates an anchor tag, assigns the URL to its href attribute, and uses the DOM API to fetch the protocol from the tag.  This PR alters that to using [the URL interface](https://developer.mozilla.org/en-US/docs/Web/API/URL).  This makes it clear to the user that we're staying in JavaScript land and will not start manipulating the visible DOM.  I would argue this is cleaner all together, but I'm very open to learning about a different opinion.  I think this helps regardless of preferred coding style within the context of this specific Hello World example.

The URL interface is more broadly supported than the `pageAction.setIcon` which this example is also dependent on, so this change should not alter browser compatibility for this Browser Extension.