### PR TITLE
Substitute about:debugging#/runtime/this-firefox for about:debugging

### DIFF
--- a/native-messaging/README.md
+++ b/native-messaging/README.md
@@ -25,7 +25,7 @@ To assist in troubleshooting on Windows, there is a script called `check_config_
 
 ## Testing the example ##
 
-Then just install the add-on as usual, by visiting about:debugging, clicking "Load Temporary Add-on", and selecting the add-on's "manifest.json".
+Then just install the add-on as usual, by visiting about:debugging#/runtime/this-firefox, clicking "Load Temporary Add-on", and selecting the add-on's "manifest.json".
 
 Now, open the extension's console using the "Inspect" button - this is where you'll see communication between the browser and native app. 
 

--- a/native-messaging/README.md
+++ b/native-messaging/README.md
@@ -25,7 +25,7 @@ To assist in troubleshooting on Windows, there is a script called `check_config_
 
 ## Testing the example ##
 
-Then just install the add-on as usual, by visiting `about:debugging#/runtime/this-firefox` or click on the button to debug "This Firefox" , clicking "Load Temporary Add-on", and selecting the add-on's "manifest.json".
+First, install the add-on. Visit `about:debugging#/runtime/this-firefox` or, from `about:debugging` click "This Firefox" (or "This Nightly" in the Nightly version of Firefox), click "Load Temporary Add-on", and open the add-on's "manifest.json".
 
 Now, open the extension's console using the "Inspect" button - this is where you'll see communication between the browser and native app. 
 

--- a/native-messaging/README.md
+++ b/native-messaging/README.md
@@ -25,7 +25,7 @@ To assist in troubleshooting on Windows, there is a script called `check_config_
 
 ## Testing the example ##
 
-Then just install the add-on as usual, by visiting about:debugging#/runtime/this-firefox, clicking "Load Temporary Add-on", and selecting the add-on's "manifest.json".
+Then just install the add-on as usual, by visiting `about:debugging#/runtime/this-firefox` or click on the button to debug "This Firefox" , clicking "Load Temporary Add-on", and selecting the add-on's "manifest.json".
 
 Now, open the extension's console using the "Inspect" button - this is where you'll see communication between the browser and native app. 
 

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -1,4 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env -S python3 -u
+# https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging
+# https://github.com/mdn/webextensions-examples/pull/157
+# Note that running python with the `-u` flag is required on Windows,
+# in order to ensure that stdin and stdout are opened in binary, rather
+# than text, mode.
 
 import sys
 import json
@@ -13,7 +18,7 @@ try:
             sys.exit(0)
         messageLength = struct.unpack('@I', rawLength)[0]
         message = sys.stdin.buffer.read(messageLength).decode('utf-8')
-        return json.loads(message)
+        return json.loads(message)["message"]
 
     # Encode a message for transmission,
     # given its content.
@@ -31,32 +36,8 @@ try:
     while True:
         receivedMessage = getMessage()
         if receivedMessage == "ping":
-            sendMessage(encodeMessage("pong3"))
-except AttributeError:
-    # Python 2.x version (if sys.stdin.buffer is not defined)
-    # Read a message from stdin and decode it.
-    def getMessage():
-        rawLength = sys.stdin.read(4)
-        if len(rawLength) == 0:
-            sys.exit(0)
-        messageLength = struct.unpack('@I', rawLength)[0]
-        message = sys.stdin.read(messageLength)
-        return json.loads(message)
-
-    # Encode a message for transmission,
-    # given its content.
-    def encodeMessage(messageContent):
-        encodedContent = json.dumps(messageContent)
-        encodedLength = struct.pack('@I', len(encodedContent))
-        return {'length': encodedLength, 'content': encodedContent}
-
-    # Send an encoded message to stdout
-    def sendMessage(encodedMessage):
-        sys.stdout.write(encodedMessage['length'])
-        sys.stdout.write(encodedMessage['content'])
-        sys.stdout.flush()
-
-    while True:
-        receivedMessage = getMessage()
-        if receivedMessage == "ping":
-            sendMessage(encodeMessage("pong2"))
+            sendMessage(encodeMessage({"message":"pong3"}))
+except Exception as e:
+    sys.stdout.buffer.flush()
+    sys.stdin.buffer.flush()
+    sys.exit(0)

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env -S python3 -u
-# https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging
-# https://github.com/mdn/webextensions-examples/pull/157
-# Note that running python with the `-u` flag is required on Windows,
-# in order to ensure that stdin and stdout are opened in binary, rather
-# than text, mode.
+#!/usr/bin/env python
 
 import sys
 import json
@@ -18,7 +13,7 @@ try:
             sys.exit(0)
         messageLength = struct.unpack('@I', rawLength)[0]
         message = sys.stdin.buffer.read(messageLength).decode('utf-8')
-        return json.loads(message)["message"]
+        return json.loads(message)
 
     # Encode a message for transmission,
     # given its content.
@@ -36,8 +31,32 @@ try:
     while True:
         receivedMessage = getMessage()
         if receivedMessage == "ping":
-            sendMessage(encodeMessage({"message":"pong3"}))
-except Exception as e:
-    sys.stdout.buffer.flush()
-    sys.stdin.buffer.flush()
-    sys.exit(0)
+            sendMessage(encodeMessage("pong3"))
+except AttributeError:
+    # Python 2.x version (if sys.stdin.buffer is not defined)
+    # Read a message from stdin and decode it.
+    def getMessage():
+        rawLength = sys.stdin.read(4)
+        if len(rawLength) == 0:
+            sys.exit(0)
+        messageLength = struct.unpack('@I', rawLength)[0]
+        message = sys.stdin.read(messageLength)
+        return json.loads(message)
+
+    # Encode a message for transmission,
+    # given its content.
+    def encodeMessage(messageContent):
+        encodedContent = json.dumps(messageContent)
+        encodedLength = struct.pack('@I', len(encodedContent))
+        return {'length': encodedLength, 'content': encodedContent}
+
+    # Send an encoded message to stdout
+    def sendMessage(encodedMessage):
+        sys.stdout.write(encodedMessage['length'])
+        sys.stdout.write(encodedMessage['content'])
+        sys.stdout.flush()
+
+    while True:
+        receivedMessage = getMessage()
+        if receivedMessage == "ping":
+            sendMessage(encodeMessage("pong2"))


### PR DESCRIPTION
Extensions are loaded at about:debugging#/runtime/this-firefox not about:debugging