### PR TITLE
Changed to runtime for beastify extension when getting content url

### DIFF
--- a/beastify/popup/choose_beast.js
+++ b/beastify/popup/choose_beast.js
@@ -11,71 +11,70 @@ const hidePage = `body > :not(.beastify-image) {
  * the content script in the page.
  */
 function listenForClicks() {
-  document.addEventListener("click", (e) => {
+    document.addEventListener("click", (e) => {
 
-    /**
-     * Given the name of a beast, get the URL to the corresponding image.
-     */
-    function beastNameToURL(beastName) {
-      switch (beastName) {
-        case "Frog":
-          return browser.extension.getURL("beasts/frog.jpg");
-        case "Snake":
-          return browser.extension.getURL("beasts/snake.jpg");
-        case "Turtle":
-          return browser.extension.getURL("beasts/turtle.jpg");
-      }
-    }
+        /**
+         * Given the name of a beast, get the URL to the corresponding image.
+         */
+        function beastNameToURL(beastName) {
+            switch (beastName) {
+                case "Frog":
+                    return browser.runtime.getURL("beasts/frog.jpg");
+                case "Snake":
+                    return browser.runtime.getURL("beasts/snake.jpg");
+                case "Turtle":
+                    return browser.runtime.getURL("beasts/turtle.jpg");
+            }
+        }
 
-    /**
-     * Insert the page-hiding CSS into the active tab,
-     * then get the beast URL and
-     * send a "beastify" message to the content script in the active tab.
-     */
-    function beastify(tabs) {
-      browser.tabs.insertCSS({code: hidePage}).then(() => {
-        let url = beastNameToURL(e.target.textContent);
-        browser.tabs.sendMessage(tabs[0].id, {
-          command: "beastify",
-          beastURL: url
-        });
-      });
-    }
+        /**
+         * Insert the page-hiding CSS into the active tab,
+         * then get the beast URL and
+         * send a "beastify" message to the content script in the active tab.
+         */
+        function beastify(tabs) {
+            browser.tabs.insertCSS({ code: hidePage }).then(() => {
+                let url = beastNameToURL(e.target.textContent);
+                browser.tabs.sendMessage(tabs[0].id, {
+                    command: "beastify",
+                    beastURL: url
+                });
+            });
+        }
 
-    /**
-     * Remove the page-hiding CSS from the active tab,
-     * send a "reset" message to the content script in the active tab.
-     */
-    function reset(tabs) {
-      browser.tabs.removeCSS({code: hidePage}).then(() => {
-        browser.tabs.sendMessage(tabs[0].id, {
-          command: "reset",
-        });
-      });
-    }
+        /**
+         * Remove the page-hiding CSS from the active tab,
+         * send a "reset" message to the content script in the active tab.
+         */
+        function reset(tabs) {
+            browser.tabs.removeCSS({ code: hidePage }).then(() => {
+                browser.tabs.sendMessage(tabs[0].id, {
+                    command: "reset",
+                });
+            });
+        }
 
-    /**
-     * Just log the error to the console.
-     */
-    function reportError(error) {
-      console.error(`Could not beastify: ${error}`);
-    }
+        /**
+         * Just log the error to the console.
+         */
+        function reportError(error) {
+            console.error(`Could not beastify: ${error}`);
+        }
 
-    /**
-     * Get the active tab,
-     * then call "beastify()" or "reset()" as appropriate.
-     */
-    if (e.target.classList.contains("beast")) {
-      browser.tabs.query({active: true, currentWindow: true})
-        .then(beastify)
-        .catch(reportError);
-    }
-    else if (e.target.classList.contains("reset")) {
-      browser.tabs.query({active: true, currentWindow: true})
-        .then(reset)
-        .catch(reportError);
-    }
-  });
+        /**
+         * Get the active tab,
+         * then call "beastify()" or "reset()" as appropriate.
+         */
+        if (e.target.classList.contains("beast")) {
+            browser.tabs.query({ active: true, currentWindow: true })
+                .then(beastify)
+                .catch(reportError);
+        } else if (e.target.classList.contains("reset")) {
+            browser.tabs.query({ active: true, currentWindow: true })
+                .then(reset)
+                .catch(reportError);
+        }
+    });
 }
 
 /**
@@ -83,9 +82,9 @@ function listenForClicks() {
  * Display the popup's error message, and hide the normal UI.
  */
 function reportExecuteScriptError(error) {
-  document.querySelector("#popup-content").classList.add("hidden");
-  document.querySelector("#error-content").classList.remove("hidden");
-  console.error(`Failed to execute beastify content script: ${error.message}`);
+    document.querySelector("#popup-content").classList.add("hidden");
+    document.querySelector("#error-content").classList.remove("hidden");
+    console.error(`Failed to execute beastify content script: ${error.message}`);
 }
 
 /**
@@ -93,6 +92,6 @@ function reportExecuteScriptError(error) {
  * and add a click handler.
  * If we couldn't inject the script, handle the error.
  */
-browser.tabs.executeScript({file: "/content_scripts/beastify.js"})
-.then(listenForClicks)
-.catch(reportExecuteScriptError);
+browser.tabs.executeScript({ file: "/content_scripts/beastify.js" })
+    .then(listenForClicks)
+    .catch(reportExecuteScriptError);

--- a/beastify/popup/choose_beast.js
+++ b/beastify/popup/choose_beast.js
@@ -11,70 +11,71 @@ const hidePage = `body > :not(.beastify-image) {
  * the content script in the page.
  */
 function listenForClicks() {
-    document.addEventListener("click", (e) => {
+  document.addEventListener("click", (e) => {
 
-        /**
-         * Given the name of a beast, get the URL to the corresponding image.
-         */
-        function beastNameToURL(beastName) {
-            switch (beastName) {
-                case "Frog":
-                    return browser.runtime.getURL("beasts/frog.jpg");
-                case "Snake":
-                    return browser.runtime.getURL("beasts/snake.jpg");
-                case "Turtle":
-                    return browser.runtime.getURL("beasts/turtle.jpg");
-            }
-        }
+    /**
+     * Given the name of a beast, get the URL to the corresponding image.
+     */
+    function beastNameToURL(beastName) {
+      switch (beastName) {
+        case "Frog":
+          return browser.runtime.getURL("beasts/frog.jpg");
+        case "Snake":
+          return browser.runtime.getURL("beasts/snake.jpg");
+        case "Turtle":
+          return browser.runtime.getURL("beasts/turtle.jpg");
+      }
+    }
 
-        /**
-         * Insert the page-hiding CSS into the active tab,
-         * then get the beast URL and
-         * send a "beastify" message to the content script in the active tab.
-         */
-        function beastify(tabs) {
-            browser.tabs.insertCSS({ code: hidePage }).then(() => {
-                let url = beastNameToURL(e.target.textContent);
-                browser.tabs.sendMessage(tabs[0].id, {
-                    command: "beastify",
-                    beastURL: url
-                });
-            });
-        }
+    /**
+     * Insert the page-hiding CSS into the active tab,
+     * then get the beast URL and
+     * send a "beastify" message to the content script in the active tab.
+     */
+    function beastify(tabs) {
+      browser.tabs.insertCSS({code: hidePage}).then(() => {
+        let url = beastNameToURL(e.target.textContent);
+        browser.tabs.sendMessage(tabs[0].id, {
+          command: "beastify",
+          beastURL: url
+        });
+      });
+    }
 
-        /**
-         * Remove the page-hiding CSS from the active tab,
-         * send a "reset" message to the content script in the active tab.
-         */
-        function reset(tabs) {
-            browser.tabs.removeCSS({ code: hidePage }).then(() => {
-                browser.tabs.sendMessage(tabs[0].id, {
-                    command: "reset",
-                });
-            });
-        }
+    /**
+     * Remove the page-hiding CSS from the active tab,
+     * send a "reset" message to the content script in the active tab.
+     */
+    function reset(tabs) {
+      browser.tabs.removeCSS({code: hidePage}).then(() => {
+        browser.tabs.sendMessage(tabs[0].id, {
+          command: "reset",
+        });
+      });
+    }
 
-        /**
-         * Just log the error to the console.
-         */
-        function reportError(error) {
-            console.error(`Could not beastify: ${error}`);
-        }
+    /**
+     * Just log the error to the console.
+     */
+    function reportError(error) {
+      console.error(`Could not beastify: ${error}`);
+    }
 
-        /**
-         * Get the active tab,
-         * then call "beastify()" or "reset()" as appropriate.
-         */
-        if (e.target.classList.contains("beast")) {
-            browser.tabs.query({ active: true, currentWindow: true })
-                .then(beastify)
-                .catch(reportError);
-        } else if (e.target.classList.contains("reset")) {
-            browser.tabs.query({ active: true, currentWindow: true })
-                .then(reset)
-                .catch(reportError);
-        }
-    });
+    /**
+     * Get the active tab,
+     * then call "beastify()" or "reset()" as appropriate.
+     */
+    if (e.target.classList.contains("beast")) {
+      browser.tabs.query({active: true, currentWindow: true})
+        .then(beastify)
+        .catch(reportError);
+    }
+    else if (e.target.classList.contains("reset")) {
+      browser.tabs.query({active: true, currentWindow: true})
+        .then(reset)
+        .catch(reportError);
+    }
+  });
 }
 
 /**
@@ -82,9 +83,9 @@ function listenForClicks() {
  * Display the popup's error message, and hide the normal UI.
  */
 function reportExecuteScriptError(error) {
-    document.querySelector("#popup-content").classList.add("hidden");
-    document.querySelector("#error-content").classList.remove("hidden");
-    console.error(`Failed to execute beastify content script: ${error.message}`);
+  document.querySelector("#popup-content").classList.add("hidden");
+  document.querySelector("#error-content").classList.remove("hidden");
+  console.error(`Failed to execute beastify content script: ${error.message}`);
 }
 
 /**
@@ -92,6 +93,6 @@ function reportExecuteScriptError(error) {
  * and add a click handler.
  * If we couldn't inject the script, handle the error.
  */
-browser.tabs.executeScript({ file: "/content_scripts/beastify.js" })
-    .then(listenForClicks)
-    .catch(reportExecuteScriptError);
+browser.tabs.executeScript({file: "/content_scripts/beastify.js"})
+.then(listenForClicks)
+.catch(reportExecuteScriptError);


### PR DESCRIPTION
Hello,
although this doesn't stop extension execution, I found using browser.runtime.getURL() instead of browser.extension.getURL() doesn't trigger an error in the browser console stating " Error: Please use $(ref:runtime.getURL) ". I have changed the code to make use of the recommended code within the beastify example. 