### PR TITLE
Eliminate space counted as message length

### DIFF
--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -18,6 +18,7 @@ try:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
+        # https://github.com/mdn/webextensions-examples/issues/509
         # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
         # https://stackoverflow.com/a/56563264
         # https://docs.python.org/3/library/json.html#basic-usage
@@ -51,6 +52,7 @@ except AttributeError:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
+        # https://github.com/mdn/webextensions-examples/issues/509
         # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
         # https://stackoverflow.com/a/56563264
         # https://docs.python.org/3/library/json.html#basic-usage

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -21,7 +21,8 @@ try:
         # https://docs.python.org/3/library/json.html#basic-usage
         # To get the most compact JSON representation, you should specify 
         # (',', ':') to eliminate whitespace.
-        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
+        # We want the most compact representation because the browser rejects
+        # messages that exceed 1 MB.
         encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -18,6 +18,11 @@ try:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
+        # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
+        # https://stackoverflow.com/a/56563264
+        # https://docs.python.org/3/library/json.html#basic-usage
+        # To get the most compact JSON representation, you should specify 
+        # (',', ':') to eliminate whitespace.
         encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}
@@ -46,6 +51,11 @@ except AttributeError:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
+        # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
+        # https://stackoverflow.com/a/56563264
+        # https://docs.python.org/3/library/json.html#basic-usage
+        # To get the most compact JSON representation, you should specify 
+        # (',', ':') to eliminate whitespace.
         encodedContent = json.dumps(messageContent, separators=(',', ':'))
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -18,7 +18,7 @@ try:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
-        encodedContent = json.dumps(messageContent).encode('utf-8')
+        encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}
 
@@ -46,7 +46,7 @@ except AttributeError:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
-        encodedContent = json.dumps(messageContent)
+        encodedContent = json.dumps(messageContent, separators=(',', ':'))
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}
 

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -18,12 +18,10 @@ try:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
-        # https://github.com/mdn/webextensions-examples/issues/509
-        # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
-        # https://stackoverflow.com/a/56563264
         # https://docs.python.org/3/library/json.html#basic-usage
         # To get the most compact JSON representation, you should specify 
         # (',', ':') to eliminate whitespace.
+        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
         encodedContent = json.dumps(messageContent, separators=(',', ':')).encode('utf-8')
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}
@@ -52,12 +50,10 @@ except AttributeError:
     # Encode a message for transmission,
     # given its content.
     def encodeMessage(messageContent):
-        # https://github.com/mdn/webextensions-examples/issues/509
-        # https://discuss.python.org/t/how-to-read-1mb-of-input-from-stdin/22534/19
-        # https://stackoverflow.com/a/56563264
         # https://docs.python.org/3/library/json.html#basic-usage
         # To get the most compact JSON representation, you should specify 
         # (',', ':') to eliminate whitespace.
+        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
         encodedContent = json.dumps(messageContent, separators=(',', ':'))
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}

--- a/native-messaging/app/ping_pong.py
+++ b/native-messaging/app/ping_pong.py
@@ -54,7 +54,8 @@ except AttributeError:
         # https://docs.python.org/3/library/json.html#basic-usage
         # To get the most compact JSON representation, you should specify 
         # (',', ':') to eliminate whitespace.
-        # We want the most compact representation because the browser rejects # messages that exceed 1 MB.
+        # We want the most compact representation because the browser rejects
+        # messages that exceed 1 MB.
         encodedContent = json.dumps(messageContent, separators=(',', ':'))
         encodedLength = struct.pack('@I', len(encodedContent))
         return {'length': encodedLength, 'content': encodedContent}


### PR DESCRIPTION
When separators=(',', ':') is not passed to json.dumps() parameter the length for input from JavaScript (which is serialized to a JSON-like format by the application (Chrome))port.postMessage(new Array(174763)); is read in Python as

1048578

which is greater than 1024*1024. Essentially space character formatting were being encoded as part of the length of the JSON.

Solved by passing separators=(',', ':') for “compact encoding” json — JSON encoder and decoder — Python 3.11.1 documentation.

Now we can write 1MB with

port.postMessage(new Array(209715));

from JavaScript and omit including and counting formatting space characters as part of encoded message length.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
