### PR TITLE
Code now reflects newer versions of browser.menus API

### DIFF
--- a/menu-demo/background.js
+++ b/menu-demo/background.js
@@ -77,14 +77,12 @@ browser.menus.create({
   contexts: ["all"]
 }, onCreated);
 
-let checkedState = true;
-
 browser.menus.create({
   id: "check-uncheck",
   type: "checkbox",
   title: browser.i18n.getMessage("menuItemUncheckMe"),
   contexts: ["all"],
-  checked: checkedState
+  checked: true,
 }, onCreated);
 
 browser.menus.create({
@@ -118,13 +116,8 @@ function borderify(tabId, color) {
 /*
 Toggle checkedState, and update the menu item's title
 appropriately.
-
-Note that we should not have to maintain checkedState independently like
-this, but have to because Firefox does not currently pass the "checked"
-property into the event listener.
 */
-function updateCheckUncheck() {
-  checkedState = !checkedState;
+function updateCheckUncheck(checkedState) {
   if (checkedState) {
     browser.menus.update("check-uncheck", {
       title: browser.i18n.getMessage("menuItemUncheckMe"),
@@ -156,7 +149,7 @@ browser.menus.onClicked.addListener((info, tab) => {
       borderify(tab.id, green);
       break;
     case "check-uncheck":
-      updateCheckUncheck();
+      updateCheckUncheck(info.checked);
       break;
     case "open-sidebar":
       console.log("Opening my sidebar");

--- a/menu-demo/background.js
+++ b/menu-demo/background.js
@@ -114,8 +114,7 @@ function borderify(tabId, color) {
 }
 
 /*
-Toggle checkedState, and update the menu item's title
-appropriately.
+Update the menu item's title according to current "checked" value.
 */
 function updateCheckUncheck(checkedState) {
   if (checkedState) {


### PR DESCRIPTION
### Description

The background script of `menu-demo` was updated to use a newer version of the `browser.menus` API, so the code doesn't need to create an extra variable `checkedState` to keep track of menu item state.

Code contains more details.

### Motivation

The previous version of the code contained a  comment saying that a feature is not supported by the Firefox version of the `browser.menus` API.

Since now it is supported, I think it should be implemented.

This way, new developers learning the API won't be confused by the information mismatch in the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/OnClickData) and the example extension.

Awesome extension by the way, it helped me a lot to understand this API.