### PR TITLE
Update root-cert-stats to use runtime.sendMessage #542

### DIFF
--- a/root-cert-stats/background.js
+++ b/root-cert-stats/background.js
@@ -3,7 +3,7 @@
 // Note: declared with "var" because popup.js references this global variable.
 // If this were to be declared with "const" or "let", then the variable would
 // still be available to this file, but not to popup.js.
-var rootCertStats = {};
+let rootCertStats = {};
 
 /*
 On an onHeadersReceived event, if there was a successful TLS connection

--- a/root-cert-stats/background.js
+++ b/root-cert-stats/background.js
@@ -1,8 +1,5 @@
 "use strict";
 
-// Note: declared with "var" because popup.js references this global variable.
-// If this were to be declared with "const" or "let", then the variable would
-// still be available to this file, but not to popup.js.
 let rootCertStats = {};
 
 /*

--- a/root-cert-stats/background.js
+++ b/root-cert-stats/background.js
@@ -39,3 +39,12 @@ browser.webRequest.onHeadersReceived.addListener(logRootCert,
   {urls: ["<all_urls>"]},
   ["blocking"]
 );
+
+/*
+Send the rootCertStats object to popup.js when requested.
+*/
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "getRootCertStats") {
+    sendResponse({ rootCertStats: rootCertStats });
+  }
+});

--- a/root-cert-stats/popup.js
+++ b/root-cert-stats/popup.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*
-Get the background page to access the rootCertStats object
+Send message to the background page to get the rootCertStats object
 */
 browser.runtime.sendMessage({ action: "getRootCertStats" }, response => {
   displayTable(response.rootCertStats);

--- a/root-cert-stats/popup.js
+++ b/root-cert-stats/popup.js
@@ -13,6 +13,9 @@ Each row contains the name of the CA and the number of times it has been
 used as a trust root.
 */
 if (entries.length > 0) {
+browser.runtime.sendMessage({ action: "getRootCertStats" }, response => {
+  displayTable(response.rootCertStats);
+});
 
   let noData = document.querySelector(".no-data");
   noData.classList.add("hidden");

--- a/root-cert-stats/popup.js
+++ b/root-cert-stats/popup.js
@@ -7,7 +7,6 @@ browser.runtime.sendMessage({ action: "getRootCertStats" }, response => {
   displayTable(response.rootCertStats);
 });
 
-const backgroundPage = browser.extension.getBackgroundPage();
 
 function displayTable(rootCertStats) {
   /*

--- a/root-cert-stats/popup.js
+++ b/root-cert-stats/popup.js
@@ -3,34 +3,36 @@
 /*
 Get the background page to access the rootCertStats object
 */
-const backgroundPage = browser.extension.getBackgroundPage();
-
-let entries = Object.keys(backgroundPage.rootCertStats);
-
-/*
-If there are any stats, show the table, and append one row for each entry.
-Each row contains the name of the CA and the number of times it has been
-used as a trust root.
-*/
-if (entries.length > 0) {
 browser.runtime.sendMessage({ action: "getRootCertStats" }, response => {
   displayTable(response.rootCertStats);
 });
 
-  let noData = document.querySelector(".no-data");
-  noData.classList.add("hidden");
-  let entryTable = document.querySelector(".root-cert-table");
-  entryTable.classList.remove("hidden");
+const backgroundPage = browser.extension.getBackgroundPage();
 
-  for (let entry of entries) {
-    let entryTR = document.createElement("tr");
-    let entryName =  document.createElement("td");
-    let entryValue =  document.createElement("td");
-    entryName.textContent = entry;
-    entryValue.textContent = backgroundPage.rootCertStats[entry];
+function displayTable(rootCertStats) {
+  /*
+  If there are any stats, show the table, and append one row for each entry.
+  Each row contains the name of the CA and the number of times it has been
+  used as a trust root.
+  */
+  let entries = Object.keys(rootCertStats);
 
-    entryTR.appendChild(entryName);
-    entryTR.appendChild(entryValue);
-    entryTable.appendChild(entryTR);
+  if (entries.length > 0) {  
+    let noData = document.querySelector(".no-data");
+    noData.classList.add("hidden");
+    let entryTable = document.querySelector(".root-cert-table");
+    entryTable.classList.remove("hidden");
+  
+    for (let entry of entries) {
+      let entryTR = document.createElement("tr");
+      let entryName =  document.createElement("td");
+      let entryValue =  document.createElement("td");
+      entryName.textContent = entry;
+      entryValue.textContent = rootCertStats[entry];
+  
+      entryTR.appendChild(entryName);
+      entryTR.appendChild(entryValue);
+      entryTable.appendChild(entryTR);
+    }
   }
 }


### PR DESCRIPTION
PR for Issue: Update root-cert-stats to use runtime.sendMessage #542 

### Description

I've added functionality for `runtime.sendMessage` and `runtime.onMessage` and it works on my browser. I had to move the table displaying into a different function; i thought it would be easier to read than to put it in the response callback function. 

If there's something which is incorrect or should be changed, let me know! 

### Related issues and pull requests

"Fixes #542"
