### PR TITLE
chore: add setup-node + npm ci to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "latest"
+          cache: "npm"
+
+      - run: npm ci
+
       - uses: reviewdog/action-eslint@v1
         with:
           reporter: github-pr-review


### PR DESCRIPTION
Fixup as follow-up to #532

Currently, any PR fails with:

> Run reviewdog/action-eslint@v1
Run $GITHUB_ACTION_PATH/script.sh
🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog
sh: 1: eslint: not found
 Running `npm install` to install eslint ...
eslint version:v8.52.0
 Running eslint with reviewdog 🐶 ...
Error: Process completed with exit code 1.