### PR TITLE
chore: use npm install instead of npm ci in gh workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: "latest"
           cache: "npm"
 
-      - run: npm ci
+      - run: npm install
 
       - uses: reviewdog/action-eslint@v1
         with:


### PR DESCRIPTION
The project does not have a package-lock.json file, so `npm ci` does not work. Switch to `npm install` instead.

Fix-up for #548. This PR should resolve the following error:

> Error: Dependencies lock file is not found in /home/runner/work/webextensions-examples/webextensions-examples. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock