### PR TITLE
Fix the example with Firefox on macOS when managed storage isn't available.

### DIFF
--- a/favourite-colour/options.js
+++ b/favourite-colour/options.js
@@ -6,8 +6,12 @@ async function saveOptions(e) {
 }
 
 async function restoreOptions() {
-  let res = await browser.storage.managed.get('colour');
-  document.querySelector("#managed-colour").innerText = res.colour;
+	try {
+		let res = await browser.storage.managed.get('colour');
+		document.querySelector("#managed-colour").innerText = res.colour;
+	} catch(error) {
+		console.log(JSON.stringify(error));
+	}
 
   res = await browser.storage.sync.get('colour');
   document.querySelector("#colour").value = res.colour || 'Firefox red';


### PR DESCRIPTION
When managed storage isn't available (i.e. : using Firefox 122 on macOS), the example code throws an exception while trying to restore the value from managed storage and never proceeds to restore the value saved in storage.sync.

This change handles the exception so that the example works out of the box.