### PR TITLE
Changed for manifest version 3 and compatibility to Chrome and CCleaner browsers

### DIFF
--- a/beastify/content_scripts/beastify.js
+++ b/beastify/content_scripts/beastify.js
@@ -1,3 +1,10 @@
+// Making compatible with Chrome
+if (typeof browser == "undefined") {
+  // `browser` is not defined in Chrome, but Manifest V3 extensions in Chrome
+  // also support promises in the `chrome` namespace, like Firefox. To easily
+  // test the example without modifications, polyfill "browser" to "chrome".
+  globalThis.browser = chrome;
+}
 (function() {
   /**
    * Check and set a global guard variable.
@@ -20,6 +27,7 @@
     beastImage.setAttribute("src", beastURL);
     beastImage.style.height = "100vh";
     beastImage.className = "beastify-image";
+    beastImage.setAttribute("id","beastify-image")
     document.body.appendChild(beastImage);
   }
 
@@ -35,7 +43,7 @@
 
   /**
    * Listen for messages from the background script.
-   * Call "beastify()" or "reset()".
+   * Call "beastify()", or "removeExistingBeasts()" for resting.
    */
   browser.runtime.onMessage.addListener((message) => {
     if (message.command === "beastify") {

--- a/beastify/manifest.json
+++ b/beastify/manifest.json
@@ -1,19 +1,20 @@
 {
 
   "description": "Adds a browser action icon to the toolbar. Click the button to choose a beast. The active tab's body content is then replaced with a picture of the chosen beast. See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples#beastify",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Beastify",
   "version": "1.0",
-  "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/beastify",
+  "homepage_url": "https://github.com/mdn/webextensions-examples/tree/main/beastify",
   "icons": {
     "48": "icons/beasts-48.png"
   },
 
   "permissions": [
-    "activeTab"
+    "activeTab", 
+    "scripting"
   ],
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/beasts-32.png",
     "theme_icons": [{
         "light": "icons/beasts-32-light.png",
@@ -25,7 +26,11 @@
   },
 
   "web_accessible_resources": [
-    "beasts/*.jpg"
+    { "resources": [ 
+        "beasts/*.jpg"
+      ],
+      "matches": ["<all_urls>"]
+    }
   ]
 
 }

--- a/examples.json
+++ b/examples.json
@@ -34,9 +34,9 @@
             "extension.getURL",
             "runtime.onMessage",
             "tabs.executeScript",
-            "tabs.insertCSS",
+            "scripting.insertCSS",
             "tabs.query",
-            "tabs.removeCSS",
+            "scripting.removeCSS",
             "tabs.sendMessage",
             "tabs.Tab"
         ],


### PR DESCRIPTION
### Description
I changed the "beastify" extension to 
   1. to run with manifest version 3
   2. to make compatible with Chrome and CC cleaner browsers


### Motivation
The changes demonstrate Mozilla extensions running with manifest version 3.


### Additional details
Unfortunately the change run very well with Chrome and CCleaner browsers, but does not run well with Firefox browser.  On Firefox browser, content JS does not load.  Pop-up and website page Debuggers does not provide any further information except a console message of "undefined: undefined" on the pop-up debugger.  I have raised a bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1884298" (Bug ID: 1884298) with Mozilla.

Nevertheless, the changes can still be helpful for developers writing compatible extensions  with manifest version 3 


### Related issues and pull requests
Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1884298
