### PR TITLE
native-messaging: fix Windows checker script not to fail on missing HKCU when HKLM is set

### DIFF
--- a/native-messaging/README.md
+++ b/native-messaging/README.md
@@ -16,7 +16,7 @@ To get this working, there's a little setup to do.
 
 ### Windows setup ###
 
-1. Check you have Python installed, and that your system's PATH environment variable includes the path to Python.  See [Using Python on Windows](https://docs.python.org/2/using/windows.html). You'll need to restart the web browser after making this change, or the browser won't pick up the new environment variable.
+1. Check you have Python installed, and that your system's PATH environment variable includes the path to Python.  See [Using Python on Windows](https://docs.python.org/3/using/windows.html). You'll need to restart the web browser after making this change, or the browser won't pick up the new environment variable.
 2. Edit the "path" property of "ping_pong.json" to point to the location of "ping_pong_win.bat" on your computer. Note that you'll need to escape the Windows directory separator, like this: `"path": "C:\\Users\\MDN\\native-messaging\\app\\ping_pong_win.bat"`.
 3. Edit "ping_pong_win.bat" to refer to the location of "ping_pong.py" on your computer.
 4. Add a registry key containing the path to "ping_pong.json" on your computer. See [App manifest location ](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_manifests#Manifest_location) to find details of the registry key to add.

--- a/native-messaging/check_config_win.py
+++ b/native-messaging/check_config_win.py
@@ -16,21 +16,15 @@ key_path = 'Software\\Mozilla\\NativeMessagingHosts\\ping_pong'
 # Assuming current user overrides local machine.
 key_roots = ['HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE']
 
-found_key = False
-
-for root in key_roots:
-    key = winreg.OpenKey(getattr(winreg, root), key_path)
+for key_root in key_roots:
     try:
-        print('Checking:', root, key_path)
+        print('Checking:', key_root, key_path)
+        key = winreg.OpenKey(getattr(winreg, key_root), key_path)
         res = winreg.QueryValueEx(key, '')
+        break
     except FileNotFoundError:
-        print('...error finding key')
-        continue
-
-    found_key = True
-    break
-
-if not found_key:
+        print('... error finding key')
+else:
     raise ValueError('Could not find a registry entry, aborting.')
 
 json_path = res[0]


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

from https://github.com/mdn/webextensions-examples/issues/557 :

> this line will throw when you create required key in `HKEY_LOCAL_MACHINE` instead of `HKEY_CURRENT_USER` ( which is allowed ) , so this script should not behave like this :
> 
> https://github.com/mdn/webextensions-examples/blob/faadfca8ddce0c02cc20c3c261c76a9b50073122/native-messaging/check_config_win.py#L22
> 
> also , as the script is in Python anyway , the whole thing can be simplified using for-else :
> 
> ```
> for root in key_roots:
>     try:
>         key = winreg.OpenKey(getattr(winreg, root), key_path)
>         print('Checking:', root, key_path)
>         res = winreg.QueryValueEx(key, '')
>     except FileNotFoundError:
>         continue
>     break
> else:
>     raise ValueError('Could not find a registry entry, aborting.')
> ```

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

i was bored

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

update : ignore the following , i created a PR for that https://github.com/mdn/content/pull/33211

btw , in the docs https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#registry there is an incorrect info about registry keys . it says "two registry entries should be created for the messaging to work" as if "both" in `HKEY_CURRENT_USER` and `HKEY_LOCAL_MACHINE` . but this is not true . only one should be . here is the proof in the Firefox source code : https://searchfox.org/mozilla-central/source/toolkit/components/extensions/NativeManifests.sys.mjs#59-83

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

fixes #557 

