### PR TITLE
Update for MV3 and Chrome compatibility

### DIFF
--- a/stored-credentials/manifest.json
+++ b/stored-credentials/manifest.json
@@ -1,6 +1,6 @@
 {
   "description": "Performs basic authentication by supplying stored credentials.",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "stored-credentials",
   "version": "2.0",
   "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/stored-credentials",
@@ -15,7 +15,8 @@
   },
 
   "background": {
-    "scripts": ["storage.js", "auth.js"]
+    "scripts": ["storage.js", "auth.js"],
+    "service_worker": "sw.js"
   },
 
   "options_ui": {
@@ -25,7 +26,11 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "storage",
+    "webRequestAuthProvider",
+    "storage"
+  ],
+
+  "host_permissions": [
     "https://httpbin.org/basic-auth/*"
   ]
 }

--- a/stored-credentials/options/options.js
+++ b/stored-credentials/options/options.js
@@ -1,3 +1,6 @@
+// Polyfill the "browser" global in Chrome.
+globalThis.browser ??= chrome;
+
 const usernameInput = document.querySelector("#username");
 const passwordInput = document.querySelector("#password");
 

--- a/stored-credentials/storage.js
+++ b/stored-credentials/storage.js
@@ -1,3 +1,6 @@
+// Polyfill the "browser" global in Chrome.
+globalThis.browser ??= chrome;
+
 /*
 Default settings. Initialize storage to these values.
 */

--- a/stored-credentials/sw.js
+++ b/stored-credentials/sw.js
@@ -1,0 +1,2 @@
+// Import and synchronously execute other JavaScript files.
+importScripts("storage.js", "auth.js");


### PR DESCRIPTION
Updates the stored-credentials example to use Manifest V3 and to add support for Chrome. This demo now works in Firefox and Chrome. It does not work in Safari because at the moment `webRequestAuthProvider` is unsupported.