### PR TITLE
Automatic theme switching support in favorite colours

### DIFF
--- a/favourite-colour/README.md
+++ b/favourite-colour/README.md
@@ -7,7 +7,7 @@ Demonstrates:
 * storing data with storage.sync
 * reading data from storage.managed
 * creating an options page and opening it with `runtime.openOptionsPage()`
-* best practice for supporting automatic theme switching in the options page
+* best practice for supporting automatic theme switching (dark theme) in the options page
 
 To have Firefox read data from storage.managed, create a file with this content:
 

--- a/favourite-colour/README.md
+++ b/favourite-colour/README.md
@@ -1,15 +1,15 @@
 # Favourite Colour
 
-Shows and stores your favourite colour, in storage.sync in the about:addons page for the add-on.
+Shows and stores your favourite colour, in storage.sync in the extension's about:addons page.
 
 Demonstrates:
 
 * storing data with storage.sync
+* reading data from storage.managed
+* creating an options page and opening it with `runtime.openOptionsPage()`
+* best practice for supporting automatic theme switching in the options page
 
-* reading data from storage.managed, 
-* creating an options page and opening it with `runtime.openOptionsPage()`.
-
-To have Firefox read data from storage.managed, create a file with the following contents:
+To have Firefox read data from storage.managed, create a file with this content:
 
     {
       "name":  "favourite-colour-examples@mozilla.org",

--- a/favourite-colour/options.html
+++ b/favourite-colour/options.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="color-scheme" content="dark light">
   </head>
 
 <body>


### PR DESCRIPTION
### Description

Adds `<meta name="color-scheme" content="dark light">` to the `<head>` section of the options.HTML file to illustrate the best practice for supporting automatic light and dark theme switching as per [Bug 1888866](https://bugzilla.mozilla.org/show_bug.cgi?id=1888866) Addons options_ui browser_style false doesn't properly handle dark mode on macOS.

### Related issues and pull requests

Related MDN content changes inhttps://github.com/mdn/content/pull/35778