### PR TITLE
Allow contributors to lint individual examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": "eslint .",
     "lint": "eslint .",
+    "lint:cwd": "eslint $INIT_CWD",
     "lint:fix": "eslint . --fix"
   },
   "license": "MIT",


### PR DESCRIPTION
### Description

This PR introduces a new npm script: `lint:cwd`. This script allows contributors to run the linter against their current directory rather than against the entire repo.

### Motivation

 It was frustrating to try to filter `npm run lint` logs for only the files that were relevant to my PR.

### Additional details

N/A

### Related issues and pull requests
N/A