### PR TITLE
Fix issue with parsing the .bat in check_config_win.py

### DIFF
--- a/native-messaging/check_config_win.py
+++ b/native-messaging/check_config_win.py
@@ -45,7 +45,7 @@ if not os.path.exists(bat_path):
 py_lines = open(bat_path, 'r').readlines()
 py_path = None
 for line in py_lines:
-    if line.startswith('call python '):
+    if line.startswith('call python3 '):
         py_path = line[12:].replace('\\\\', '\\').strip()
 
 if not py_path:


### PR DESCRIPTION
The setup instructions for `native-messaging` are specific to `python3`. As `ping_pong_win.bat` has the command `call python3`, however the `check_config_win.py` is checking for the string literal `"call python "` which will always evaluate to false due to the trailing space.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
