### PR TITLE
Correct userScripts / userScripts_legacy index

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -569,7 +569,7 @@
   {
     "description": "Illustrates how an extension can register URL-matching user scripts at runtime (Manifest Version 2 only).",
     "javascript_apis": [
-      "userScripts.register",
+      "userScripts_legacy.register",
       "runtime.onMessage",
       "runtime.sendMessage"
     ],
@@ -588,6 +588,7 @@
       "permissions.onRemoved",
       "permissions.request",
       "runtime.onInstalled",
+      "runtime.onMessage",
       "runtime.onUserScriptMessage",
       "runtime.openOptionsPage",
       "runtime.sendMessage",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

The MV2-specific userScripts example is currently associated with the "userScripts.register" API. While this is the correct API name, the MDN documentation is actually at `userScripts_legacy/register`.

To make sure that the example is rendered in the right location, change "userScripts" to "userScripts_legacy".

... and for completeness also add `runtime.onMessage` to the MV3 example, since that example uses this API.

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->
The user-script-register example currently appears at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register#example_extensions, but it should not. Instead, it should be at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/register

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

With this patch, the example will be moved to the correct location, as desired.

The index of all examples, at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Examples, ~would show `userScripts_legacy.register` instead of `userScripts.register (legacy)`. This is a mild issue, and I plan to address that by submitting a patch to the logic at https://github.com/mdn/yari/blob/79c4a5ef6b2807e52b851ec4b54f0def71b0f319/kumascript/macros/WebExtAllExamples.ejs#L48~
I tested locally, and the link is rendered as `userScripts.register() (Legacy)`, as desired, as explained at https://github.com/mdn/yari/pull/12677#issuecomment-2686089461.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

This is a follow-up to https://github.com/mdn/content/pull/38073 and https://github.com/mdn/webextensions-examples/pull/576.