### PR TITLE
Drop dead video link (load temp addon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ To run an example extension:
 1. Open Firefox and load the `about:debugging` page. Click 
    [Load Temporary Add-on](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox)
    and select the `manifest.json` file within the folder of an example extension.
-   Here is a [video](https://www.youtube.com/watch?v=cer9EUKegG4)
-   that demonstrates how to do this.
 2. Install the
    [web-ext](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext)
    tool. At the command line, open the example extension's folder and type


### PR DESCRIPTION
The video is short, old, macOS-only, and has been unpublicized from YouTube.

The Internet Archive has it [archived in 2021](http://web.archive.org/web/20210221034604/https://www.youtube.com/watch?v=cer9EUKegG4).

Given that opening the archived site is not a very user friendly way or guidance (slow, confusion regarding missing content, YouTube reference, etc), and the intentional removal done by publishers, it seems more appropriate to drop the link.

Resolves #574