### PR TITLE
Prevent chrome API access

### DIFF
--- a/userScripts-mv3/userscript_api.js
+++ b/userScripts-mv3/userscript_api.js
@@ -18,6 +18,7 @@ globalThis.initCustomAPIForUserScripts = grants => {
   // Clear access to privileged API to prevent userscripts from communicating
   // to the privileged backend.
   globalThis.browser = undefined;
+  globalThis.chrome = undefined;
 
   if (grants.includes("GM_info")) {
     // Example of an API that retrieves information:


### PR DESCRIPTION
`chrome.runtime.connect` & `chrome.runtime.sendMessage` are still accessible to userscripts.