### PR TITLE
Increase minimum version to 136.0

### DIFF
--- a/userScripts-mv3/manifest.json
+++ b/userScripts-mv3/manifest.json
@@ -15,7 +15,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "user-script-manager-example@mozilla.org",
-      "strict_min_version": "134.0"
+      "strict_min_version": "136.0"
     }
   }
 }


### PR DESCRIPTION
Increase the minimum version to match the official [userScripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts#browser_compatibility) API release.