### PR TITLE
Add an item to group the active tab in a new group.

### DIFF
--- a/tabs-tabs-tabs/tabs.html
+++ b/tabs-tabs-tabs/tabs.html
@@ -25,6 +25,7 @@
 
     <a href="#" id="tabs-create">Create a tab</a><br>
     <a href="#" id="tabs-remove">Remove active tab</a><br>
+    <a href="#" id="tabs-group">Add active tab to New Group</a><br>
 
     <div class="panel-section-separator"></div>
 

--- a/tabs-tabs-tabs/tabs.html
+++ b/tabs-tabs-tabs/tabs.html
@@ -25,7 +25,7 @@
 
     <a href="#" id="tabs-create">Create a tab</a><br>
     <a href="#" id="tabs-remove">Remove active tab</a><br>
-    <a href="#" id="tabs-group">Add active tab to New Group</a><br>
+    <a href="#" id="tabs-group">Add active tab to a new group</a><br>
 
     <div class="panel-section-separator"></div>
 

--- a/tabs-tabs-tabs/tabs.js
+++ b/tabs-tabs-tabs/tabs.js
@@ -98,6 +98,12 @@ document.addEventListener("click", (e) => {
     });
   }
 
+  else if (e.target.id === "tabs-group") {
+    callOnActiveTab((tab) => {
+      browser.tabs.group({ tabIds: [tab.id] });
+    });
+  }
+
   else if (e.target.id === "tabs-create") {
     browser.tabs.create({url: "https://developer.mozilla.org/en-US/Add-ons/WebExtensions"});
   }


### PR DESCRIPTION

### Description

Modifies the tabs, tabs, tabs extension to demonstrate the usage of the tabs.group method.

### Motivation

The extension demonstrates other tabs-related methods but the group method is missing.

### Additional details

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/group

### Related issues and pull requests

N/A