### PR TITLE
typo: Native Messaging Docs

### DIFF
--- a/native-messaging/add-on/background.js
+++ b/native-messaging/add-on/background.js
@@ -19,7 +19,7 @@ port.onDisconnect.addListener((port) => {
   } else {
     // The port closed for an unspecified reason. If this occurred right after
     // calling `browser.runtime.connectNative()` there may have been a problem
-    // starting the the native messaging client in the first place.
+    // starting the native messaging client in the first place.
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#troubleshooting
     console.log(`Disconnected`, port);
   }


### PR DESCRIPTION
Removes a secondary use of 'the'.

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
Fixes a small typo, there were two uses of 'the' in a sentence.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation
Grammatical clarity.
<!-- ❓ Why are you making these changes and how do they help? -->

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
