### PR TITLE
Migration of notify-link-clicks-i18n to MV3

### DIFF
--- a/notify-link-clicks-i18n/README.md
+++ b/notify-link-clicks-i18n/README.md
@@ -1,17 +1,19 @@
 # notify-link-clicks-i18n
 
-**This add-on injects JavaScript into web pages. The `addons.mozilla.org` domain disallows this operation, so this add-on will not work properly when it's run on pages in the `addons.mozilla.org` domain.**
+This add-on injects JavaScript into web pages that passes messages to the extension's background script when a link is clicked. The background script use the information in the message to create a notification. The extension illustrates how to localize the content of the notification as well as the extension's name and description.
 
 ## What it does
 
-This extension includes:
+This extension includes a:
 
-* a content script, "content-script.js", that is injected into all pages
-* a background script, "background-script.js"
+* Content script, "content-script.js", that is injected into all pages.
+* Background script, "background-script.js".
 
 The content script listens for clicks in the page it's attached to.
 If a click is on a link, the content script sends the link's href
 to the background script.
+
+**The `addons.mozilla.org` domain doesn't allow scripts to be injected into its pages. Therefore, this extension doesn't work on pages in the `addons.mozilla.org` domain.**
 
 The background script listens for this message. When the background script
 receives the message, it displays a notification containing the href.
@@ -21,7 +23,7 @@ localized into German, Dutch, and Japanese, as well as the default en-US.
 
 # What it shows
 
-* how to inject content scripts declaratively using manifest.json
-* how to send messages from a content script to a background script
-* how to display system notifications using the notifications API
-* how to use the internationalization (i18n) system
+* How to inject content scripts declaratively using manifest.json.
+* How to send messages from a content script to a background script.
+* How to display system notifications using the notifications API.
+* How to use the internationalization (i18n) system.

--- a/notify-link-clicks-i18n/README.md
+++ b/notify-link-clicks-i18n/README.md
@@ -23,7 +23,9 @@ localized into German, Dutch, and Japanese, as well as the default en-US.
 
 # What it shows
 
-* How to inject content scripts declaratively using manifest.json.
-* How to send messages from a content script to a background script.
-* How to display system notifications using the notifications API.
-* How to use the internationalization (i18n) system.
+This example extension shows how to:
+
+* Inject content scripts declaratively using manifest.json.
+* Send messages from a content script to a background script.
+* Display system notifications using the notifications API.
+* Use the internationalization (i18n) system.

--- a/notify-link-clicks-i18n/background-script.js
+++ b/notify-link-clicks-i18n/background-script.js
@@ -9,7 +9,7 @@ function notify(message) {
   let content = browser.i18n.getMessage("notificationContent", message.url);
   browser.notifications.create({
     "type": "basic",
-    "iconUrl": browser.extension.getURL("icons/link-48.png"),
+    "iconUrl": browser.runtime.getURL("icons/link-48.png"),
     "title": title,
     "message": content
   });

--- a/notify-link-clicks-i18n/manifest.json
+++ b/notify-link-clicks-i18n/manifest.json
@@ -1,6 +1,6 @@
 {
 
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "version": "1.0",

--- a/notify-link-clicks-i18n/manifest.json
+++ b/notify-link-clicks-i18n/manifest.json
@@ -9,6 +9,15 @@
     "48": "icons/link-48.png"
   },
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "notify-link-clicks-i18n@mozilla.org",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
+
   "permissions": ["notifications"],
 
   "background": {


### PR DESCRIPTION
### Description

This PR migrated this example to use Manifest V3. 

### Motivation

Manifest V3 is now the recommended manifest version for web extensions.

### Related issues and pull requests

Related content changes on MDN https://github.com/mdn/content/pull/42679

