### PR TITLE
Replace `contextMenus` with `menus`

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -106,8 +106,8 @@
   {
     "description": "Add a context menu option to links to copy the link to the clipboard, as plain text and as a link in rich HTML.",
     "javascript_apis": [
-      "contextMenus.create",
-      "contextMenus.onClicked",
+      "menus.create",
+      "menus.onClicked",
       "tabs.executeScript"
     ],
     "name": "context-menu-copy-link-with-types"
@@ -494,8 +494,8 @@
     "description": "Demonstrates how to use the idb-file-storage library to store and manipulate files in an extension.",
     "javascript_apis": [
       "browserAction.onClicked",
-      "contextMenus.create",
-      "contextMenus.onClicked",
+      "menus.create",
+      "menus.onClicked",
       "runtime.onMessage",
       "runtime.sendMessage",
       "tabs.create",


### PR DESCRIPTION
### Description

Replace `contextMenus` with `menus`.

### Motivation

Resolves `webextallexamples` flaws reported by `@mdn/rari`.

### Additional details

See: https://caugner.github.io/mdn-flawless/#locale=en-US&templ=webextallexamples

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

See also:

- https://github.com/mdn/content/pull/44041
- https://github.com/mdn/content/pull/44090