### PR TITLE
ci(CODEOWNERS): add default owner, remove `examples.json` owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
+*                   @mdn/add-ons
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
-/examples.json      @mdn/engineering
 /SECURITY.md        @mdn/engineering


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `CODEOWNERS`:

1. Adds `@mdn/add-ons` as default owner.
2. Removes `@mdn/engineering` as `examples.json` owner.

### Motivation

1. All MDN repos should have a default owner to ensure every PR is assigned a reviewer.
2. Avoid that changes to `examples.json` are blocked by MDN Engineering.

### Additional details

`@mdn/engineering` was codeowner of `examples.json`, because this file is consumed directly by Rari, so bad changes may cause our build to fail. However, this hasn't happened yet, and we should add a required workflow check for this instead.

### Related issues and pull requests

Fixes https://github.com/mdn/webextensions-examples/issues/632.