### PR TITLE
`images.additional_backgrounds` correction in weta tiled theme

### DIFF
--- a/themes/weta_tiled/manifest.json
+++ b/themes/weta_tiled/manifest.json
@@ -8,7 +8,7 @@
 
   "theme": {
     "images": {
-      "additional_backgrounds": "weta_for_tiling.png"
+      "additional_backgrounds": [ "weta_for_tiling.png" ]
     },
 
     "properties": {


### PR DESCRIPTION
### Description

The theme erroneously set `images.additional_backgrounds` as a value, not an array.

### Motivation

To create the correct example so it can be loaded.
